### PR TITLE
Add a step to ask if the user has an existing store

### DIFF
--- a/client/components/steps/existing-store.jsx
+++ b/client/components/steps/existing-store.jsx
@@ -1,0 +1,81 @@
+var React = require( 'react' ),
+	SiteStore = require( 'stores/site-store' ),
+	SetupProgressActions = require( 'actions/setup-progress-actions' ),
+	WelcomeSection = require( '../page/container' ),
+	Paths = require( 'constants/jetpack-onboarding-paths' ),
+	Button = require( '@automattic/dops-components/client/components/button' );
+
+var SelectDropdown = require( '@automattic/dops-components/client/components/select-dropdown' ),
+	DropdownItem = require( '@automattic/dops-components/client/components/select-dropdown/item' );
+
+function getJetpackState() {
+	const { is_shop } = JPS.bloginfo;
+	return {
+		site_title: SiteStore.getTitle(),
+		wooCommerceStatus: SiteStore.getWooCommerceStatus(),
+		wooCommerceSetupUrl: SiteStore.getWooCommerceSetupUrl(),
+		is_shop
+	};
+}
+
+const platforms = [
+	'Shopify',
+	'BigCommerce',
+	'Magento',
+	'Woo',
+	'osCommerce',
+	'Wix',
+	'Other'
+];
+
+module.exports = React.createClass( {
+
+	componentDidMount: function() {
+		SiteStore.addChangeListener( this._onChange );
+	},
+
+	componentWillUnmount: function() {
+		SiteStore.removeChangeListener( this._onChange );
+	},
+
+	_onChange: function() {
+		this.setState( getJetpackState() );
+	},
+
+	getInitialState: function() {
+		return getJetpackState();
+	},
+
+	submitStorePlatform: function( platform ) {
+		SetupProgressActions.completeStep( Paths.EXISTING_STORE_STEP_SLUG, { platform } );
+		this.goToJpoReview();
+	},
+
+	goToJpoReview: function() {
+		SetupProgressActions.setCurrentStep( Paths.REVIEW_STEP_SLUG );
+	},
+
+	render: function() {
+		const platformSelections = platforms.map( ( platform, i ) => {
+			return (
+				<DropdownItem key={ i } onClick={ () => {
+					this.submitStorePlatform( platform );
+				} }>{ platform }</DropdownItem>
+			);
+		} );
+
+		return (
+			<WelcomeSection id="welcome__jetpack">
+				<h1>Let&apos;s launch <em>{ this.state.site_title }</em></h1>
+				<p className="welcome__callout welcome__jetpack--callout">{ 'Do you already have an existing e-commerce store?' }</p>
+				<div className="welcome__existing-store--button-container welcome__button-container">
+					<SelectDropdown selectedText="Yes, it's powered by…" className="welcome__existing-store--dropdown">
+						{ platformSelections }
+					</SelectDropdown>
+					<Button primary>Next</Button>
+					<Button>Nope</Button>
+				</div>
+			</WelcomeSection>
+		);
+	}
+} );

--- a/client/components/steps/existing-store.jsx
+++ b/client/components/steps/existing-store.jsx
@@ -56,6 +56,10 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
+		if ( ! this.state.is_store ) {
+			this.goToJpoReview();
+		}
+
 		const platformSelections = platforms.map( ( platform, i ) => {
 			return (
 				<DropdownItem key={ i } onClick={ () => {

--- a/client/components/steps/existing-store.jsx
+++ b/client/components/steps/existing-store.jsx
@@ -76,8 +76,8 @@ module.exports = React.createClass( {
 					<SelectDropdown selectedText="Yes, it's powered by…" className="welcome__existing-store--dropdown">
 						{ platformSelections }
 					</SelectDropdown>
-					<Button primary>Next</Button>
-					<Button>Nope</Button>
+					<Button primary onClick={ this.goToJpoReview }>Next</Button>
+					<Button onClick={ this.goToJpoReview }>Nope</Button>
 				</div>
 			</WelcomeSection>
 		);

--- a/client/components/steps/existing-store.jsx
+++ b/client/components/steps/existing-store.jsx
@@ -22,7 +22,7 @@ const platforms = [
 	'Shopify',
 	'BigCommerce',
 	'Magento',
-	'Woo',
+	'WooCommerce',
 	'osCommerce',
 	'Wix',
 	'Other'
@@ -56,7 +56,7 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
-		if ( ! this.state.is_store ) {
+		if ( ! this.state.wooCommerceStatus ) {
 			this.goToJpoReview();
 		}
 

--- a/client/components/steps/woocommerce.jsx
+++ b/client/components/steps/woocommerce.jsx
@@ -51,6 +51,10 @@ module.exports = React.createClass( {
 		SetupProgressActions.setCurrentStep( Paths.REVIEW_STEP_SLUG );
 	},
 
+	goToMigrateStep: function() {
+		SetupProgressActions.setCurrentStep( Paths.EXISTING_STORE_STEP_SLUG );
+	},
+
 	handleSubmit: function( event ) {
 		event.preventDefault();
 		SiteActions.installWooCommerce();
@@ -64,7 +68,7 @@ module.exports = React.createClass( {
 
 					<div className="welcome__button-container">
 						<Button className='welcome-submit' primary type="submit">Install WooCommerce</Button>
-						<SkipButton />
+						<SkipButton handleSkip={ this.goToJpoReview } />
 					</div>
 				</form>
 			</div>
@@ -77,7 +81,7 @@ module.exports = React.createClass( {
 				<p className="welcome__callout welcome__jetpack--callout">WooCommerce is ready to go</p>
 				<div className="welcome__button-container">
 					<Button className='welcome-submit' primary onClick={ this.goToWooSetup }>Setup your store</Button>
-					<Button onClick={ this.goToJpoReview }>Not right now</Button>
+					<Button onClick={ this.goToMigrateStep }>Not right now</Button>
 				</div>
 			</div>
 		);

--- a/client/constants/jetpack-onboarding-paths.js
+++ b/client/constants/jetpack-onboarding-paths.js
@@ -11,5 +11,6 @@ module.exports = {
 	JETPACK_MODULES_STEP_SLUG: 'jetpack',
 	CONTACT_PAGE_STEP_SLUG: 'contact-page',
 	BUSINESS_ADDRESS_SLUG: 'business-address',
-	WOOCOMMERCE_SLUG: 'woocommerce'
+	WOOCOMMERCE_SLUG: 'woocommerce',
+	EXISTING_STORE_STEP_SLUG: 'existing-store'
 };

--- a/client/welcome-panel.jsx
+++ b/client/welcome-panel.jsx
@@ -5,8 +5,7 @@ var React = require( 'react' ),
 	SetupProgressStore = require( 'stores/setup-progress-store' );
 
 module.exports = function() {
-	jQuery( document ).ready( function () {
-
+	jQuery( document ).ready( function() {
 		SetupProgressStore.init( [
 			// NOTE: You can have "static: true" to include un-clickable
 			// prefilled steps that act as though they've already been completed
@@ -18,43 +17,48 @@ module.exports = function() {
 			{
 				name: 'Site title',
 				slug: Paths.SITE_TITLE_STEP_SLUG,
-				welcomeView: require('./components/steps/site-title')
+				welcomeView: require( './components/steps/site-title' ),
 			},
 			{
 				name: 'Is this a blog?',
 				slug: Paths.IS_BLOG_STEP_SLUG,
-				welcomeView: require('./components/steps/layout')
+				welcomeView: require( './components/steps/layout' ),
 			},
 			{
 				name: 'Set your homepage',
 				slug: Paths.HOMEPAGE_STEP_SLUG,
-				welcomeView: require('./components/steps/homepage')
+				welcomeView: require( './components/steps/homepage' ),
 			},
 			{
-				name: "Contact Info",
+				name: 'Contact Info',
 				slug: Paths.CONTACT_PAGE_STEP_SLUG,
-				welcomeView: require('./components/steps/contact')
+				welcomeView: require( './components/steps/contact' ),
 			},
 			{
 				name: 'Enable Jetpack',
 				slug: Paths.JETPACK_MODULES_STEP_SLUG,
 				neverSkip: true, // don't skip this even if it's been completed
-				welcomeView: require('./components/steps/jetpack-jumpstart'),
+				welcomeView: require( './components/steps/jetpack-jumpstart' ),
 			},
 			{
 				name: 'Business Address',
 				slug: Paths.BUSINESS_ADDRESS_SLUG,
-				welcomeView: require('./components/steps/business-address'),
+				welcomeView: require( './components/steps/business-address' ),
 			},
 			{
 				name: 'WooCommerce',
 				slug: Paths.WOOCOMMERCE_SLUG,
-				welcomeView: require('./components/steps/woocommerce'),
+				welcomeView: require( './components/steps/woocommerce' ),
 			},
 			{
-				name: "Review settings",
+				name: 'Existing Store',
+				slug: Paths.EXISTING_STORE_STEP_SLUG,
+				welcomeView: require( './components/steps/existing-store' ),
+			},
+			{
+				name: 'Review settings',
 				slug: Paths.REVIEW_STEP_SLUG,
-				welcomeView: require('./components/steps/review'),
+				welcomeView: require( './components/steps/review' ),
 				includeInProgress: false,
 				neverSkip: true
 			}

--- a/css/scss/_existing-store.scss
+++ b/css/scss/_existing-store.scss
@@ -1,0 +1,20 @@
+.welcome__existing-store--dropdown {
+	.dops-select-dropdown__header {
+		height: auto;
+	}
+}
+
+.welcome__existing-store--button-container {
+	display: flex;
+	margin: auto;
+	max-width: 400px;
+	justify-content: space-between;
+
+	& > * {
+		flex: 0 auto;
+	}
+
+	button + button {
+		margin-left: 0;
+	}
+}

--- a/css/scss/welcome-panel.scss
+++ b/css/scss/welcome-panel.scss
@@ -21,3 +21,4 @@ $very-light-gray: #f5f5f5;
 @import 'jetpack-jumpstart';
 @import 'business-address';
 @import 'woocommerce';
+@import 'existing-store';

--- a/css/welcome-panel.css
+++ b/css/welcome-panel.css
@@ -582,3 +582,25 @@ img.welcome__get-started-image {
   .welcome__container .welcome__woocommerce--install-container .welcome__woocommerce--checkbox {
     float: none;
     margin: 1px 8px 0 0; }
+
+.welcome__container .dops-select-dropdown__header {
+  height: auto; }
+
+.welcome__existing-store--dropdown .dops-select-dropdown__header {
+  height: auto; }
+
+.welcome__existing-store--button-container {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  margin: auto;
+  max-width: 400px;
+  -webkit-box-pack: justify;
+      -ms-flex-pack: justify;
+          justify-content: space-between; }
+  .welcome__existing-store--button-container > * {
+    -webkit-box-flex: 0;
+        -ms-flex: 0 auto;
+            flex: 0 auto; }
+  .welcome__existing-store--button-container button + button {
+    margin-left: 0; }

--- a/dist/jetpack-onboarding.css
+++ b/dist/jetpack-onboarding.css
@@ -132,3 +132,193 @@
       width: 18px;
       height: 18px;
       top: 5px; }
+.dops-count {
+  display: inline-block;
+  padding: 0.0625rem 0.375rem;
+  border: solid 1px #87a6bc;
+  border-radius: 0.75rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  line-height: 0.875rem;
+  color: #87a6bc;
+  text-align: center; }
+/**
+ * Select Dropdown
+ */
+.dops-select-dropdown {
+  height: 43px; }
+  .dops-select-dropdown.is-compact {
+    height: 28px; }
+
+.dops-select-dropdown__container {
+  position: relative;
+  overflow: hidden;
+  display: inline-block;
+  width: auto;
+  max-width: 100%; }
+  .dops-select-dropdown.is-open .dops-select-dropdown__container {
+    z-index: 170; }
+  .dops-accessible-focus .dops-select-dropdown__container:focus,
+  .dops-accessible-focus .dops-select-dropdown.is-open .dops-select-dropdown__container {
+    z-index: 170;
+    box-shadow: 0 0 0 2px #78dcfa; }
+    .dops-accessible-focus .dops-select-dropdown__container:focus .select-dropdown__header,
+    .dops-accessible-focus .dops-select-dropdown.is-open .dops-select-dropdown__container .select-dropdown__header {
+      border-color: #0087be; }
+  .dops-accessible-focus .dops-select-dropdown__container:focus {
+    border-color: #00aadc;
+    box-shadow: 0 0 0 2px #78dcfa;
+    outline: 0;
+    border-radius: 4px; }
+
+.dops-select-dropdown__header {
+  padding: 11px 44px 11px 16px;
+  border-style: solid;
+  border-color: #c8d7e1;
+  border-width: 1px 1px 2px;
+  border-radius: 4px;
+  background-color: white;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 18px;
+  height: 18px;
+  color: #2e4453;
+  -webkit-transition: background-color 0.2s ease;
+  transition: background-color 0.2s ease;
+  cursor: pointer; }
+  .dops-select-dropdown__header::after {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    display: inline-block;
+    vertical-align: middle;
+    font: normal 16px/1 'Dashicons';
+    content: '\F347';
+    position: absolute;
+    right: 13px;
+    top: 12px;
+    display: block;
+    line-height: 18px;
+    color: rgba(135, 166, 188, 0.5); }
+    .is-compact .dops-select-dropdown__header::after {
+      right: 4px;
+      top: 4px; }
+  .is-compact .dops-select-dropdown__header {
+    padding: 7px;
+    color: #668eaa;
+    font-size: 11px;
+    line-height: 1;
+    text-transform: uppercase; }
+    .is-compact .dops-select-dropdown__header .dops-count {
+      border-width: 0;
+      margin-left: 0;
+      line-height: 1; }
+  .dops-select-dropdown.is-open .dops-select-dropdown__header {
+    border-radius: 4px 4px 0 0;
+    box-shadow: none;
+    background-color: #f3f6f8; }
+    .dops-select-dropdown.is-open .dops-select-dropdown__header::after {
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      display: inline-block;
+      vertical-align: middle;
+      font: normal 16px/1 'Dashicons';
+      content: '\F343'; }
+  .dops-select-dropdown__header .dops-count {
+    margin-left: 8px; }
+
+.dops-select-dropdown__header-text {
+  display: block;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden; }
+
+.dops-select-dropdown__options {
+  visibility: hidden;
+  height: 0;
+  box-sizing: border-box;
+  padding: 0;
+  list-style: none;
+  margin: -2px 0 0 0;
+  background-color: white;
+  border: 1px solid #c8d7e1;
+  border-radius: 0 0 4px 4px; }
+  .dops-accessible-focus .dops-select-dropdown__options {
+    border: solid 1px #0087be;
+    border-top-color: #c8d7e1; }
+  .dops-select-dropdown.is-open .dops-select-dropdown__options {
+    visibility: visible;
+    height: auto; }
+
+.dops-select-dropdown__option:last-child .dops-select-dropdown__item {
+  border-radius: 0 0 4px 4px; }
+
+.dops-select-dropdown__item,
+.dops-select-dropdown__item-text {
+  padding: 11px 44px 11px 16px; }
+
+.dops-select-dropdown__item {
+  display: block;
+  position: relative;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 18px;
+  color: #2e4453;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  cursor: pointer; }
+  .dops-select-dropdown__item::before {
+    content: attr(data-bold-text);
+    font-weight: 700;
+    opacity: 0; }
+  .dops-select-dropdown__item:visited {
+    color: #2e4453; }
+  .dops-select-dropdown__item.is-selected {
+    background-color: #00aadc;
+    color: white; }
+  .dops-select-dropdown__item.is-disabled {
+    background-color: white;
+    color: #87a6bc;
+    cursor: default;
+    opacity: .5; }
+  .notouch .dops-select-dropdown__item:hover {
+    color: #00aadc; }
+  .notouch .dops-select-dropdown__item.is-selected:hover {
+    color: white; }
+
+.dops-select-dropdown__item-text {
+  padding-right: 16px;
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  color: inherit;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-flow: row wrap;
+      flex-flow: row wrap;
+  -webkit-box-pack: justify;
+      -ms-flex-pack: justify;
+          justify-content: space-between; }
+  .dops-select-dropdown__item-text .dops-count {
+    color: inherit;
+    border-color: inherit; }
+
+.dops-select-dropdown__separator {
+  border-top: 1px solid #c8d7e1;
+  display: block;
+  margin: 8px 0; }
+
+.dops-select-dropdown__label {
+  display: block;
+  color: #a8bece;
+  margin-top: 5px;
+  line-height: 20px; }
+  .dops-select-dropdown__label label {
+    font-size: 12px;
+    text-transform: uppercase;
+    padding: 0px 16px 0px 16px; }

--- a/dist/jetpack-onboarding.js
+++ b/dist/jetpack-onboarding.js
@@ -24,7 +24,6 @@ webpackJsonp([1],[
 
 	module.exports = function () {
 		jQuery(document).ready(function () {
-
 			SetupProgressStore.init([
 			// NOTE: You can have "static: true" to include un-clickable
 			// prefilled steps that act as though they've already been completed
@@ -46,7 +45,7 @@ webpackJsonp([1],[
 				slug: Paths.HOMEPAGE_STEP_SLUG,
 				welcomeView: __webpack_require__(263)
 			}, {
-				name: "Contact Info",
+				name: 'Contact Info',
 				slug: Paths.CONTACT_PAGE_STEP_SLUG,
 				welcomeView: __webpack_require__(264)
 			}, {
@@ -63,9 +62,13 @@ webpackJsonp([1],[
 				slug: Paths.WOOCOMMERCE_SLUG,
 				welcomeView: __webpack_require__(269)
 			}, {
-				name: "Review settings",
+				name: 'Existing Store',
+				slug: Paths.EXISTING_STORE_STEP_SLUG,
+				welcomeView: __webpack_require__(270)
+			}, {
+				name: 'Review settings',
 				slug: Paths.REVIEW_STEP_SLUG,
-				welcomeView: __webpack_require__(270),
+				welcomeView: __webpack_require__(366),
 				includeInProgress: false,
 				neverSkip: true
 			}]);
@@ -1570,7 +1573,8 @@ webpackJsonp([1],[
 		JETPACK_MODULES_STEP_SLUG: 'jetpack',
 		CONTACT_PAGE_STEP_SLUG: 'contact-page',
 		BUSINESS_ADDRESS_SLUG: 'business-address',
-		WOOCOMMERCE_SLUG: 'woocommerce'
+		WOOCOMMERCE_SLUG: 'woocommerce',
+		EXISTING_STORE_STEP_SLUG: 'existing-store'
 	};
 
 /***/ },
@@ -5441,6 +5445,10 @@ webpackJsonp([1],[
 			SetupProgressActions.setCurrentStep(Paths.REVIEW_STEP_SLUG);
 		},
 
+		goToMigrateStep: function goToMigrateStep() {
+			SetupProgressActions.setCurrentStep(Paths.EXISTING_STORE_STEP_SLUG);
+		},
+
 		handleSubmit: function handleSubmit(event) {
 			event.preventDefault();
 			SiteActions.installWooCommerce();
@@ -5466,7 +5474,7 @@ webpackJsonp([1],[
 							{ className: 'welcome-submit', primary: true, type: 'submit' },
 							'Install WooCommerce'
 						),
-						React.createElement(SkipButton, null)
+						React.createElement(SkipButton, { handleSkip: this.goToJpoReview })
 					)
 				)
 			);
@@ -5491,7 +5499,7 @@ webpackJsonp([1],[
 					),
 					React.createElement(
 						Button,
-						{ onClick: this.goToJpoReview },
+						{ onClick: this.goToMigrateStep },
 						'Not right now'
 					)
 				)
@@ -5524,10 +5532,3784 @@ webpackJsonp([1],[
 	'use strict';
 
 	var React = __webpack_require__(4),
+	    SiteStore = __webpack_require__(215),
+	    SetupProgressActions = __webpack_require__(174),
+	    WelcomeSection = __webpack_require__(259),
+	    Paths = __webpack_require__(175),
+	    Button = __webpack_require__(224);
+
+	var SelectDropdown = __webpack_require__(271),
+	    DropdownItem = __webpack_require__(357);
+
+	function getJetpackState() {
+		var is_shop = JPS.bloginfo.is_shop;
+
+		return {
+			site_title: SiteStore.getTitle(),
+			wooCommerceStatus: SiteStore.getWooCommerceStatus(),
+			wooCommerceSetupUrl: SiteStore.getWooCommerceSetupUrl(),
+			is_shop: is_shop
+		};
+	}
+
+	var platforms = ['Shopify', 'BigCommerce', 'Magento', 'Woo', 'osCommerce', 'Wix', 'Other'];
+
+	module.exports = React.createClass({
+		displayName: 'exports',
+
+
+		componentDidMount: function componentDidMount() {
+			SiteStore.addChangeListener(this._onChange);
+		},
+
+		componentWillUnmount: function componentWillUnmount() {
+			SiteStore.removeChangeListener(this._onChange);
+		},
+
+		_onChange: function _onChange() {
+			this.setState(getJetpackState());
+		},
+
+		getInitialState: function getInitialState() {
+			return getJetpackState();
+		},
+
+		submitStorePlatform: function submitStorePlatform(platform) {
+			SetupProgressActions.completeStep(Paths.EXISTING_STORE_STEP_SLUG, { platform: platform });
+			this.goToJpoReview();
+		},
+
+		goToJpoReview: function goToJpoReview() {
+			SetupProgressActions.setCurrentStep(Paths.REVIEW_STEP_SLUG);
+		},
+
+		render: function render() {
+			var _this = this;
+
+			var platformSelections = platforms.map(function (platform, i) {
+				return React.createElement(
+					DropdownItem,
+					{ key: i, onClick: function onClick() {
+							_this.submitStorePlatform(platform);
+						} },
+					platform
+				);
+			});
+
+			return React.createElement(
+				WelcomeSection,
+				{ id: 'welcome__jetpack' },
+				React.createElement(
+					'h1',
+					null,
+					'Let\'s launch ',
+					React.createElement(
+						'em',
+						null,
+						this.state.site_title
+					)
+				),
+				React.createElement(
+					'p',
+					{ className: 'welcome__callout welcome__jetpack--callout' },
+					'Do you already have an existing e-commerce store?'
+				),
+				React.createElement(
+					'div',
+					{ className: 'welcome__existing-store--button-container welcome__button-container' },
+					React.createElement(
+						SelectDropdown,
+						{ selectedText: 'Yes, it\'s powered by\u2026', className: 'welcome__existing-store--dropdown' },
+						platformSelections
+					),
+					React.createElement(
+						Button,
+						{ primary: true },
+						'Next'
+					),
+					React.createElement(
+						Button,
+						null,
+						'Nope'
+					)
+				)
+			);
+		}
+	});
+
+/***/ },
+/* 271 */
+/***/ function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+		value: true
+	});
+
+	var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+	var _reactDom = __webpack_require__(33);
+
+	var _reactDom2 = _interopRequireDefault(_reactDom);
+
+	var _react = __webpack_require__(4);
+
+	var _react2 = _interopRequireDefault(_react);
+
+	var _find = __webpack_require__(272);
+
+	var _find2 = _interopRequireDefault(_find);
+
+	var _filter = __webpack_require__(350);
+
+	var _filter2 = _interopRequireDefault(_filter);
+
+	var _findIndex = __webpack_require__(353);
+
+	var _findIndex2 = _interopRequireDefault(_findIndex);
+
+	var _map = __webpack_require__(354);
+
+	var _map2 = _interopRequireDefault(_map);
+
+	var _result = __webpack_require__(356);
+
+	var _result2 = _interopRequireDefault(_result);
+
+	var _classnames = __webpack_require__(254);
+
+	var _classnames2 = _interopRequireDefault(_classnames);
+
+	var _item = __webpack_require__(357);
+
+	var _item2 = _interopRequireDefault(_item);
+
+	var _separator = __webpack_require__(363);
+
+	var _separator2 = _interopRequireDefault(_separator);
+
+	var _label = __webpack_require__(364);
+
+	var _label2 = _interopRequireDefault(_label);
+
+	var _count = __webpack_require__(358);
+
+	var _count2 = _interopRequireDefault(_count);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+	function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+	function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; } /** @ssr-ready **/
+
+	/**
+	 * External Dependencies
+	 */
+
+
+	/**
+	 * Internal dependencies
+	 */
+
+
+	__webpack_require__(365);
+
+	/**
+	 * Module variables
+	 */
+	var Component = _react2.default.Component,
+	    PropTypes = _react2.default.PropTypes;
+
+	var noop = function noop() {};
+
+	/**
+	 * SelectDropdown
+	 */
+
+	var SelectDropdown = function (_Component) {
+		_inherits(SelectDropdown, _Component);
+
+		function SelectDropdown(props) {
+			_classCallCheck(this, SelectDropdown);
+
+			// bounds
+			var _this = _possibleConstructorReturn(this, (SelectDropdown.__proto__ || Object.getPrototypeOf(SelectDropdown)).call(this, props));
+
+			_this.navigateItem = _this.navigateItem.bind(_this);
+			_this.toggleDropdown = _this.toggleDropdown.bind(_this);
+			_this.handleOutsideClick = _this.handleOutsideClick.bind(_this);
+
+			// state
+			var initialState = { isOpen: false };
+
+			if (props.options.length) {
+				initialState.selected = _this.getInitialSelectedItem(props);
+			}
+
+			_this.state = initialState;
+			return _this;
+		}
+
+		_createClass(SelectDropdown, [{
+			key: 'componentWillMount',
+			value: function componentWillMount() {
+				this.setState({
+					instanceId: ++SelectDropdown.instances
+				});
+			}
+		}, {
+			key: 'componentWillReceiveProps',
+			value: function componentWillReceiveProps(nextProps) {
+				if (this.state.isOpen) {
+					this.closeDropdown();
+				}
+
+				if (typeof this.state.selected !== 'undefined' && this.props.initialSelected !== nextProps.initialSelected) {
+					this.setState({ selected: nextProps.initialSelected });
+				}
+			}
+		}, {
+			key: 'componentWillUnmount',
+			value: function componentWillUnmount() {
+				window.removeEventListener('click', this.handleOutsideClick);
+			}
+		}, {
+			key: 'componentDidUpdate',
+			value: function componentDidUpdate(prevProps, prevState) {
+				if (this.state.isOpen) {
+					window.addEventListener('click', this.handleOutsideClick);
+				} else {
+					window.removeEventListener('click', this.handleOutsideClick);
+				}
+
+				if (this.state.isOpen !== prevState.isOpen) {
+					this.props.onToggle({
+						target: this,
+						open: this.state.isOpen
+					});
+				}
+			}
+		}, {
+			key: 'getInitialSelectedItem',
+			value: function getInitialSelectedItem(props) {
+				props = props || this.props;
+
+				if (props.initialSelected) {
+					return props.initialSelected;
+				}
+
+				if (!props.options.length) {
+					return;
+				}
+
+				var selectedItem = (0, _find2.default)(props.options, function (value) {
+					return !value.isLabel;
+				});
+				return selectedItem && selectedItem.value;
+			}
+		}, {
+			key: 'dropdownOptions',
+			value: function dropdownOptions() {
+				var refIndex = 0;
+				var self = this;
+
+				if (this.props.children) {
+					// add keys and refs to children
+					return _react2.default.Children.map(this.props.children, function (child, index) {
+						if (!child) {
+							return null;
+						}
+
+						var newChild = _react2.default.cloneElement(child, {
+							ref: child.type === _item2.default ? 'item-' + refIndex : null,
+							key: 'item-' + index,
+							onClick: function onClick(event) {
+								self.refs.dropdownContainer.focus();
+								if (typeof child.props.onClick === 'function') {
+									child.props.onClick(event);
+								}
+							}
+						});
+
+						if (child.type === _item2.default) {
+							refIndex++;
+						}
+
+						return newChild;
+					}, this);
+				}
+
+				return this.props.options.map(function (item, index) {
+					if (!item) {
+						return _react2.default.createElement(_separator2.default, {
+							key: 'dropdown-separator-' + this.state.instanceId + '-' + index
+						});
+					}
+
+					if (item.isLabel) {
+						return _react2.default.createElement(
+							_label2.default,
+							{
+								key: 'dropdown-label-' + this.state.instanceId + '-' + index
+							},
+							item.label
+						);
+					}
+
+					var dropdownItem = _react2.default.createElement(
+						_item2.default,
+						{
+							key: 'dropdown-item-' + this.state.instanceId + '-' + item.value,
+							ref: 'item-' + refIndex,
+							selected: this.state.selected === item.value,
+							onClick: this.onSelectItem(item),
+							path: item.path
+						},
+						item.label
+					);
+
+					refIndex++;
+
+					return dropdownItem;
+				}, this);
+			}
+		}, {
+			key: 'render',
+			value: function render() {
+				var dropdownClasses = {
+					'dops-select-dropdown': true,
+					'is-compact': this.props.compact,
+					'is-open': this.state.isOpen
+				};
+
+				if (this.props.className) {
+					this.props.className.split(' ').forEach(function (className) {
+						dropdownClasses[className] = true;
+					});
+				}
+
+				var dropdownClassName = (0, _classnames2.default)(dropdownClasses);
+				var selectedText = this.props.selectedText ? this.props.selectedText : (0, _result2.default)((0, _find2.default)(this.props.options, { value: this.state.selected }), 'label');
+
+				return _react2.default.createElement(
+					'div',
+					{ style: this.props.style, className: dropdownClassName },
+					_react2.default.createElement(
+						'div',
+						{
+							ref: 'dropdownContainer',
+							className: 'dops-select-dropdown__container',
+							valueLink: this.props.valueLink,
+							onKeyDown: this.navigateItem,
+							tabIndex: this.props.tabIndex || 0,
+							'aria-haspopup': 'true',
+							'aria-owns': 'select-submenu-' + this.state.instanceId,
+							'aria-controls': 'select-submenu-' + this.state.instanceId,
+							'aria-expanded': this.state.isOpen,
+							onClick: this.toggleDropdown
+						},
+						_react2.default.createElement(
+							'div',
+							{
+								id: 'select-dropdown-' + this.state.instanceId,
+								className: 'dops-select-dropdown__header'
+							},
+							_react2.default.createElement(
+								'span',
+								{ className: 'dops-select-dropdown__header-text' },
+								selectedText,
+								'number' === typeof this.props.selectedCount && _react2.default.createElement(_count2.default, { count: this.props.selectedCount })
+							)
+						),
+						_react2.default.createElement(
+							'ul',
+							{
+								id: 'select-submenu-' + this.state.instanceId,
+								className: 'dops-select-dropdown__options',
+								role: 'menu',
+								'aria-labelledby': 'select-dropdown-' + this.state.instanceId,
+								'aria-expanded': this.state.isOpen
+							},
+							this.dropdownOptions()
+						)
+					)
+				);
+			}
+		}, {
+			key: 'toggleDropdown',
+			value: function toggleDropdown() {
+				this.setState({
+					isOpen: !this.state.isOpen
+				});
+			}
+		}, {
+			key: 'openDropdown',
+			value: function openDropdown() {
+				this.setState({
+					isOpen: true
+				});
+			}
+		}, {
+			key: 'closeDropdown',
+			value: function closeDropdown() {
+				if (this.state.isOpen) {
+					delete this.focused;
+					this.setState({
+						isOpen: false
+					});
+				}
+			}
+		}, {
+			key: 'onSelectItem',
+			value: function onSelectItem(option) {
+				return this.selectItem.bind(this, option);
+			}
+		}, {
+			key: 'selectItem',
+			value: function selectItem(option) {
+				if (!option) {
+					return;
+				}
+
+				if (this.props.onSelect) {
+					this.props.onSelect(option);
+				}
+
+				this.setState({
+					selected: option.value
+				});
+
+				this.refs.dropdownContainer.focus();
+			}
+		}, {
+			key: 'navigateItem',
+			value: function navigateItem(event) {
+				switch (event.keyCode) {
+					case 9:
+						//tab
+						this.navigateItemByTabKey(event);
+						break;
+					case 32: // space
+					case 13:
+						// enter
+						event.preventDefault();
+						this.activateItem();
+						break;
+					case 38:
+						// up arrow
+						event.preventDefault();
+						this.focusSibling('previous');
+						this.openDropdown();
+						break;
+					case 40:
+						// down arrow
+						event.preventDefault();
+						this.focusSibling('next');
+						this.openDropdown();
+						break;
+					case 27:
+						// escape
+						event.preventDefault();
+						this.closeDropdown();
+						this.refs.dropdownContainer.focus();
+						break;
+				}
+			}
+		}, {
+			key: 'navigateItemByTabKey',
+			value: function navigateItemByTabKey(event) {
+				var direction;
+				if (!this.state.isOpen) {
+					return;
+				}
+				event.preventDefault();
+				direction = event.shiftKey ? 'previous' : 'next';
+				this.focusSibling(direction);
+			}
+		}, {
+			key: 'activateItem',
+			value: function activateItem() {
+				if (!this.state.isOpen) {
+					return this.openDropdown();
+				}
+				document.activeElement.click();
+			}
+		}, {
+			key: 'focusSibling',
+			value: function focusSibling(direction) {
+				var increment, items, focusedIndex, newIndex;
+
+				// the initial up-arrow/down-arrow should only open the menu
+				if (!this.state.isOpen) {
+					return;
+				}
+
+				if (this.props.options.length) {
+					items = (0, _map2.default)((0, _filter2.default)(this.props.options, function (item) {
+						return item && !item.isLabel;
+					}), 'value');
+
+					focusedIndex = typeof this.focused === 'number' ? this.focused : items.indexOf(this.state.selected);
+				} else {
+					items = (0, _filter2.default)(this.props.children, function (item) {
+						return item.type === _item2.default;
+					});
+
+					focusedIndex = typeof this.focused === 'number' ? this.focused : (0, _findIndex2.default)(items, function (item) {
+						return item.props.selected;
+					});
+				}
+
+				increment = direction === 'previous' ? -1 : 1;
+				newIndex = focusedIndex + increment;
+
+				if (newIndex >= items.length || newIndex < 0) {
+					return;
+				}
+
+				_reactDom2.default.findDOMNode(this.refs['item-' + newIndex].refs.itemLink).focus();
+				this.focused = newIndex;
+			}
+		}, {
+			key: 'handleOutsideClick',
+			value: function handleOutsideClick(event) {
+				if (!_reactDom2.default.findDOMNode(this.refs.dropdownContainer).contains(event.target)) {
+					this.closeDropdown();
+				}
+			}
+		}]);
+
+		return SelectDropdown;
+	}(Component);
+
+	;
+
+	SelectDropdown.defaultProps = {
+		options: [],
+		onSelect: noop,
+		onToggle: noop,
+		style: {}
+	};
+
+	SelectDropdown.propTypes = {
+		selectedText: PropTypes.string,
+		selectedCount: PropTypes.number,
+		initialSelected: PropTypes.string,
+		className: PropTypes.string,
+		style: PropTypes.object,
+		onSelect: PropTypes.func,
+		onToggle: PropTypes.func,
+		focusSibling: PropTypes.func,
+		tabIndex: PropTypes.number,
+		options: PropTypes.arrayOf(PropTypes.shape({
+			value: PropTypes.string.isRequired,
+			label: PropTypes.string.isRequired,
+			path: PropTypes.string
+		}))
+	};
+
+	// statics
+	SelectDropdown.instances = 0;
+
+	exports.default = SelectDropdown;
+	module.exports = exports['default'];
+
+/***/ },
+/* 272 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var baseEach = __webpack_require__(273),
+	    baseFind = __webpack_require__(278),
+	    baseFindIndex = __webpack_require__(279),
+	    baseIteratee = __webpack_require__(280),
+	    isArray = __webpack_require__(251);
+
+	/**
+	 * Iterates over elements of `collection`, returning the first element
+	 * `predicate` returns truthy for. The predicate is invoked with three arguments:
+	 * (value, index|key, collection).
+	 *
+	 * @static
+	 * @memberOf _
+	 * @category Collection
+	 * @param {Array|Object} collection The collection to search.
+	 * @param {Function|Object|string} [predicate=_.identity] The function invoked per iteration.
+	 * @returns {*} Returns the matched element, else `undefined`.
+	 * @example
+	 *
+	 * var users = [
+	 *   { 'user': 'barney',  'age': 36, 'active': true },
+	 *   { 'user': 'fred',    'age': 40, 'active': false },
+	 *   { 'user': 'pebbles', 'age': 1,  'active': true }
+	 * ];
+	 *
+	 * _.find(users, function(o) { return o.age < 40; });
+	 * // => object for 'barney'
+	 *
+	 * // The `_.matches` iteratee shorthand.
+	 * _.find(users, { 'age': 1, 'active': true });
+	 * // => object for 'pebbles'
+	 *
+	 * // The `_.matchesProperty` iteratee shorthand.
+	 * _.find(users, ['active', false]);
+	 * // => object for 'fred'
+	 *
+	 * // The `_.property` iteratee shorthand.
+	 * _.find(users, 'active');
+	 * // => object for 'barney'
+	 */
+	function find(collection, predicate) {
+	  predicate = baseIteratee(predicate, 3);
+	  if (isArray(collection)) {
+	    var index = baseFindIndex(collection, predicate);
+	    return index > -1 ? collection[index] : undefined;
+	  }
+	  return baseFind(collection, predicate, baseEach);
+	}
+
+	module.exports = find;
+
+
+/***/ },
+/* 273 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var baseForOwn = __webpack_require__(274),
+	    createBaseEach = __webpack_require__(277);
+
+	/**
+	 * The base implementation of `_.forEach` without support for iteratee shorthands.
+	 *
+	 * @private
+	 * @param {Array|Object} collection The collection to iterate over.
+	 * @param {Function} iteratee The function invoked per iteration.
+	 * @returns {Array|Object} Returns `collection`.
+	 */
+	var baseEach = createBaseEach(baseForOwn);
+
+	module.exports = baseEach;
+
+
+/***/ },
+/* 274 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var baseFor = __webpack_require__(275),
+	    keys = __webpack_require__(243);
+
+	/**
+	 * The base implementation of `_.forOwn` without support for iteratee shorthands.
+	 *
+	 * @private
+	 * @param {Object} object The object to iterate over.
+	 * @param {Function} iteratee The function invoked per iteration.
+	 * @returns {Object} Returns `object`.
+	 */
+	function baseForOwn(object, iteratee) {
+	  return object && baseFor(object, iteratee, keys);
+	}
+
+	module.exports = baseForOwn;
+
+
+/***/ },
+/* 275 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var createBaseFor = __webpack_require__(276);
+
+	/**
+	 * The base implementation of `baseForIn` and `baseForOwn` which iterates
+	 * over `object` properties returned by `keysFunc` invoking `iteratee` for
+	 * each property. Iteratee functions may exit iteration early by explicitly
+	 * returning `false`.
+	 *
+	 * @private
+	 * @param {Object} object The object to iterate over.
+	 * @param {Function} iteratee The function invoked per iteration.
+	 * @param {Function} keysFunc The function to get the keys of `object`.
+	 * @returns {Object} Returns `object`.
+	 */
+	var baseFor = createBaseFor();
+
+	module.exports = baseFor;
+
+
+/***/ },
+/* 276 */
+/***/ function(module, exports) {
+
+	/**
+	 * Creates a base function for methods like `_.forIn`.
+	 *
+	 * @private
+	 * @param {boolean} [fromRight] Specify iterating from right to left.
+	 * @returns {Function} Returns the new base function.
+	 */
+	function createBaseFor(fromRight) {
+	  return function(object, iteratee, keysFunc) {
+	    var index = -1,
+	        iterable = Object(object),
+	        props = keysFunc(object),
+	        length = props.length;
+
+	    while (length--) {
+	      var key = props[fromRight ? length : ++index];
+	      if (iteratee(iterable[key], key, iterable) === false) {
+	        break;
+	      }
+	    }
+	    return object;
+	  };
+	}
+
+	module.exports = createBaseFor;
+
+
+/***/ },
+/* 277 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var isArrayLike = __webpack_require__(232);
+
+	/**
+	 * Creates a `baseEach` or `baseEachRight` function.
+	 *
+	 * @private
+	 * @param {Function} eachFunc The function to iterate over a collection.
+	 * @param {boolean} [fromRight] Specify iterating from right to left.
+	 * @returns {Function} Returns the new base function.
+	 */
+	function createBaseEach(eachFunc, fromRight) {
+	  return function(collection, iteratee) {
+	    if (collection == null) {
+	      return collection;
+	    }
+	    if (!isArrayLike(collection)) {
+	      return eachFunc(collection, iteratee);
+	    }
+	    var length = collection.length,
+	        index = fromRight ? length : -1,
+	        iterable = Object(collection);
+
+	    while ((fromRight ? index-- : ++index < length)) {
+	      if (iteratee(iterable[index], index, iterable) === false) {
+	        break;
+	      }
+	    }
+	    return collection;
+	  };
+	}
+
+	module.exports = createBaseEach;
+
+
+/***/ },
+/* 278 */
+/***/ function(module, exports) {
+
+	/**
+	 * The base implementation of methods like `_.find` and `_.findKey`, without
+	 * support for iteratee shorthands, which iterates over `collection` using
+	 * `eachFunc`.
+	 *
+	 * @private
+	 * @param {Array|Object} collection The collection to search.
+	 * @param {Function} predicate The function invoked per iteration.
+	 * @param {Function} eachFunc The function to iterate over `collection`.
+	 * @param {boolean} [retKey] Specify returning the key of the found element instead of the element itself.
+	 * @returns {*} Returns the found element or its key, else `undefined`.
+	 */
+	function baseFind(collection, predicate, eachFunc, retKey) {
+	  var result;
+	  eachFunc(collection, function(value, key, collection) {
+	    if (predicate(value, key, collection)) {
+	      result = retKey ? key : value;
+	      return false;
+	    }
+	  });
+	  return result;
+	}
+
+	module.exports = baseFind;
+
+
+/***/ },
+/* 279 */
+/***/ function(module, exports) {
+
+	/**
+	 * The base implementation of `_.findIndex` and `_.findLastIndex` without
+	 * support for iteratee shorthands.
+	 *
+	 * @private
+	 * @param {Array} array The array to search.
+	 * @param {Function} predicate The function invoked per iteration.
+	 * @param {boolean} [fromRight] Specify iterating from right to left.
+	 * @returns {number} Returns the index of the matched value, else `-1`.
+	 */
+	function baseFindIndex(array, predicate, fromRight) {
+	  var length = array.length,
+	      index = fromRight ? length : -1;
+
+	  while ((fromRight ? index-- : ++index < length)) {
+	    if (predicate(array[index], index, array)) {
+	      return index;
+	    }
+	  }
+	  return -1;
+	}
+
+	module.exports = baseFindIndex;
+
+
+/***/ },
+/* 280 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var baseMatches = __webpack_require__(281),
+	    baseMatchesProperty = __webpack_require__(333),
+	    identity = __webpack_require__(347),
+	    isArray = __webpack_require__(251),
+	    property = __webpack_require__(348);
+
+	/**
+	 * The base implementation of `_.iteratee`.
+	 *
+	 * @private
+	 * @param {*} [value=_.identity] The value to convert to an iteratee.
+	 * @returns {Function} Returns the iteratee.
+	 */
+	function baseIteratee(value) {
+	  var type = typeof value;
+	  if (type == 'function') {
+	    return value;
+	  }
+	  if (value == null) {
+	    return identity;
+	  }
+	  if (type == 'object') {
+	    return isArray(value)
+	      ? baseMatchesProperty(value[0], value[1])
+	      : baseMatches(value);
+	  }
+	  return property(value);
+	}
+
+	module.exports = baseIteratee;
+
+
+/***/ },
+/* 281 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var baseIsMatch = __webpack_require__(282),
+	    getMatchData = __webpack_require__(328);
+
+	/**
+	 * The base implementation of `_.matches` which doesn't clone `source`.
+	 *
+	 * @private
+	 * @param {Object} source The object of property values to match.
+	 * @returns {Function} Returns the new function.
+	 */
+	function baseMatches(source) {
+	  var matchData = getMatchData(source);
+	  if (matchData.length == 1 && matchData[0][2]) {
+	    var key = matchData[0][0],
+	        value = matchData[0][1];
+
+	    return function(object) {
+	      if (object == null) {
+	        return false;
+	      }
+	      return object[key] === value &&
+	        (value !== undefined || (key in Object(object)));
+	    };
+	  }
+	  return function(object) {
+	    return object === source || baseIsMatch(object, source, matchData);
+	  };
+	}
+
+	module.exports = baseMatches;
+
+
+/***/ },
+/* 282 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var Stack = __webpack_require__(283),
+	    baseIsEqual = __webpack_require__(314);
+
+	/** Used to compose bitmasks for comparison styles. */
+	var UNORDERED_COMPARE_FLAG = 1,
+	    PARTIAL_COMPARE_FLAG = 2;
+
+	/**
+	 * The base implementation of `_.isMatch` without support for iteratee shorthands.
+	 *
+	 * @private
+	 * @param {Object} object The object to inspect.
+	 * @param {Object} source The object of property values to match.
+	 * @param {Array} matchData The property names, values, and compare flags to match.
+	 * @param {Function} [customizer] The function to customize comparisons.
+	 * @returns {boolean} Returns `true` if `object` is a match, else `false`.
+	 */
+	function baseIsMatch(object, source, matchData, customizer) {
+	  var index = matchData.length,
+	      length = index,
+	      noCustomizer = !customizer;
+
+	  if (object == null) {
+	    return !length;
+	  }
+	  object = Object(object);
+	  while (index--) {
+	    var data = matchData[index];
+	    if ((noCustomizer && data[2])
+	          ? data[1] !== object[data[0]]
+	          : !(data[0] in object)
+	        ) {
+	      return false;
+	    }
+	  }
+	  while (++index < length) {
+	    data = matchData[index];
+	    var key = data[0],
+	        objValue = object[key],
+	        srcValue = data[1];
+
+	    if (noCustomizer && data[2]) {
+	      if (objValue === undefined && !(key in object)) {
+	        return false;
+	      }
+	    } else {
+	      var stack = new Stack,
+	          result = customizer ? customizer(objValue, srcValue, key, object, source, stack) : undefined;
+
+	      if (!(result === undefined
+	            ? baseIsEqual(srcValue, objValue, customizer, UNORDERED_COMPARE_FLAG | PARTIAL_COMPARE_FLAG, stack)
+	            : result
+	          )) {
+	        return false;
+	      }
+	    }
+	  }
+	  return true;
+	}
+
+	module.exports = baseIsMatch;
+
+
+/***/ },
+/* 283 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var stackClear = __webpack_require__(284),
+	    stackDelete = __webpack_require__(285),
+	    stackGet = __webpack_require__(288),
+	    stackHas = __webpack_require__(290),
+	    stackSet = __webpack_require__(292);
+
+	/**
+	 * Creates a stack cache object to store key-value pairs.
+	 *
+	 * @private
+	 * @constructor
+	 * @param {Array} [values] The values to cache.
+	 */
+	function Stack(values) {
+	  var index = -1,
+	      length = values ? values.length : 0;
+
+	  this.clear();
+	  while (++index < length) {
+	    var entry = values[index];
+	    this.set(entry[0], entry[1]);
+	  }
+	}
+
+	// Add functions to the `Stack` cache.
+	Stack.prototype.clear = stackClear;
+	Stack.prototype['delete'] = stackDelete;
+	Stack.prototype.get = stackGet;
+	Stack.prototype.has = stackHas;
+	Stack.prototype.set = stackSet;
+
+	module.exports = Stack;
+
+
+/***/ },
+/* 284 */
+/***/ function(module, exports) {
+
+	/**
+	 * Removes all key-value entries from the stack.
+	 *
+	 * @private
+	 * @name clear
+	 * @memberOf Stack
+	 */
+	function stackClear() {
+	  this.__data__ = { 'array': [], 'map': null };
+	}
+
+	module.exports = stackClear;
+
+
+/***/ },
+/* 285 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var assocDelete = __webpack_require__(286);
+
+	/**
+	 * Removes `key` and its value from the stack.
+	 *
+	 * @private
+	 * @name delete
+	 * @memberOf Stack
+	 * @param {string} key The key of the value to remove.
+	 * @returns {boolean} Returns `true` if the entry was removed, else `false`.
+	 */
+	function stackDelete(key) {
+	  var data = this.__data__,
+	      array = data.array;
+
+	  return array ? assocDelete(array, key) : data.map['delete'](key);
+	}
+
+	module.exports = stackDelete;
+
+
+/***/ },
+/* 286 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var assocIndexOf = __webpack_require__(287);
+
+	/** Used for built-in method references. */
+	var arrayProto = Array.prototype;
+
+	/** Built-in value references. */
+	var splice = arrayProto.splice;
+
+	/**
+	 * Removes `key` and its value from the associative array.
+	 *
+	 * @private
+	 * @param {Array} array The array to query.
+	 * @param {string} key The key of the value to remove.
+	 * @returns {boolean} Returns `true` if the entry was removed, else `false`.
+	 */
+	function assocDelete(array, key) {
+	  var index = assocIndexOf(array, key);
+	  if (index < 0) {
+	    return false;
+	  }
+	  var lastIndex = array.length - 1;
+	  if (index == lastIndex) {
+	    array.pop();
+	  } else {
+	    splice.call(array, index, 1);
+	  }
+	  return true;
+	}
+
+	module.exports = assocDelete;
+
+
+/***/ },
+/* 287 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var eq = __webpack_require__(229);
+
+	/**
+	 * Gets the index at which the first occurrence of `key` is found in `array`
+	 * of key-value pairs.
+	 *
+	 * @private
+	 * @param {Array} array The array to search.
+	 * @param {*} key The key to search for.
+	 * @returns {number} Returns the index of the matched value, else `-1`.
+	 */
+	function assocIndexOf(array, key) {
+	  var length = array.length;
+	  while (length--) {
+	    if (eq(array[length][0], key)) {
+	      return length;
+	    }
+	  }
+	  return -1;
+	}
+
+	module.exports = assocIndexOf;
+
+
+/***/ },
+/* 288 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var assocGet = __webpack_require__(289);
+
+	/**
+	 * Gets the stack value for `key`.
+	 *
+	 * @private
+	 * @name get
+	 * @memberOf Stack
+	 * @param {string} key The key of the value to get.
+	 * @returns {*} Returns the entry value.
+	 */
+	function stackGet(key) {
+	  var data = this.__data__,
+	      array = data.array;
+
+	  return array ? assocGet(array, key) : data.map.get(key);
+	}
+
+	module.exports = stackGet;
+
+
+/***/ },
+/* 289 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var assocIndexOf = __webpack_require__(287);
+
+	/**
+	 * Gets the associative array value for `key`.
+	 *
+	 * @private
+	 * @param {Array} array The array to query.
+	 * @param {string} key The key of the value to get.
+	 * @returns {*} Returns the entry value.
+	 */
+	function assocGet(array, key) {
+	  var index = assocIndexOf(array, key);
+	  return index < 0 ? undefined : array[index][1];
+	}
+
+	module.exports = assocGet;
+
+
+/***/ },
+/* 290 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var assocHas = __webpack_require__(291);
+
+	/**
+	 * Checks if a stack value for `key` exists.
+	 *
+	 * @private
+	 * @name has
+	 * @memberOf Stack
+	 * @param {string} key The key of the entry to check.
+	 * @returns {boolean} Returns `true` if an entry for `key` exists, else `false`.
+	 */
+	function stackHas(key) {
+	  var data = this.__data__,
+	      array = data.array;
+
+	  return array ? assocHas(array, key) : data.map.has(key);
+	}
+
+	module.exports = stackHas;
+
+
+/***/ },
+/* 291 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var assocIndexOf = __webpack_require__(287);
+
+	/**
+	 * Checks if an associative array value for `key` exists.
+	 *
+	 * @private
+	 * @param {Array} array The array to query.
+	 * @param {string} key The key of the entry to check.
+	 * @returns {boolean} Returns `true` if an entry for `key` exists, else `false`.
+	 */
+	function assocHas(array, key) {
+	  return assocIndexOf(array, key) > -1;
+	}
+
+	module.exports = assocHas;
+
+
+/***/ },
+/* 292 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var MapCache = __webpack_require__(293),
+	    assocSet = __webpack_require__(312);
+
+	/** Used as the size to enable large array optimizations. */
+	var LARGE_ARRAY_SIZE = 200;
+
+	/**
+	 * Sets the stack `key` to `value`.
+	 *
+	 * @private
+	 * @name set
+	 * @memberOf Stack
+	 * @param {string} key The key of the value to set.
+	 * @param {*} value The value to set.
+	 * @returns {Object} Returns the stack cache object.
+	 */
+	function stackSet(key, value) {
+	  var data = this.__data__,
+	      array = data.array;
+
+	  if (array) {
+	    if (array.length < (LARGE_ARRAY_SIZE - 1)) {
+	      assocSet(array, key, value);
+	    } else {
+	      data.array = null;
+	      data.map = new MapCache(array);
+	    }
+	  }
+	  var map = data.map;
+	  if (map) {
+	    map.set(key, value);
+	  }
+	  return this;
+	}
+
+	module.exports = stackSet;
+
+
+/***/ },
+/* 293 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var mapClear = __webpack_require__(294),
+	    mapDelete = __webpack_require__(304),
+	    mapGet = __webpack_require__(308),
+	    mapHas = __webpack_require__(310),
+	    mapSet = __webpack_require__(311);
+
+	/**
+	 * Creates a map cache object to store key-value pairs.
+	 *
+	 * @private
+	 * @constructor
+	 * @param {Array} [values] The values to cache.
+	 */
+	function MapCache(values) {
+	  var index = -1,
+	      length = values ? values.length : 0;
+
+	  this.clear();
+	  while (++index < length) {
+	    var entry = values[index];
+	    this.set(entry[0], entry[1]);
+	  }
+	}
+
+	// Add functions to the `MapCache`.
+	MapCache.prototype.clear = mapClear;
+	MapCache.prototype['delete'] = mapDelete;
+	MapCache.prototype.get = mapGet;
+	MapCache.prototype.has = mapHas;
+	MapCache.prototype.set = mapSet;
+
+	module.exports = MapCache;
+
+
+/***/ },
+/* 294 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var Hash = __webpack_require__(295),
+	    Map = __webpack_require__(300);
+
+	/**
+	 * Removes all key-value entries from the map.
+	 *
+	 * @private
+	 * @name clear
+	 * @memberOf MapCache
+	 */
+	function mapClear() {
+	  this.__data__ = {
+	    'hash': new Hash,
+	    'map': Map ? new Map : [],
+	    'string': new Hash
+	  };
+	}
+
+	module.exports = mapClear;
+
+
+/***/ },
+/* 295 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var nativeCreate = __webpack_require__(296);
+
+	/** Used for built-in method references. */
+	var objectProto = Object.prototype;
+
+	/**
+	 * Creates an hash object.
+	 *
+	 * @private
+	 * @constructor
+	 * @returns {Object} Returns the new hash object.
+	 */
+	function Hash() {}
+
+	// Avoid inheriting from `Object.prototype` when possible.
+	Hash.prototype = nativeCreate ? nativeCreate(null) : objectProto;
+
+	module.exports = Hash;
+
+
+/***/ },
+/* 296 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var getNative = __webpack_require__(297);
+
+	/* Built-in method references that are verified to be native. */
+	var nativeCreate = getNative(Object, 'create');
+
+	module.exports = nativeCreate;
+
+
+/***/ },
+/* 297 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var isNative = __webpack_require__(298);
+
+	/**
+	 * Gets the native function at `key` of `object`.
+	 *
+	 * @private
+	 * @param {Object} object The object to query.
+	 * @param {string} key The key of the method to get.
+	 * @returns {*} Returns the function if it's native, else `undefined`.
+	 */
+	function getNative(object, key) {
+	  var value = object == null ? undefined : object[key];
+	  return isNative(value) ? value : undefined;
+	}
+
+	module.exports = getNative;
+
+
+/***/ },
+/* 298 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var isFunction = __webpack_require__(235),
+	    isHostObject = __webpack_require__(299),
+	    isObjectLike = __webpack_require__(250);
+
+	/** Used to match `RegExp` [syntax characters](http://ecma-international.org/ecma-262/6.0/#sec-patterns). */
+	var reRegExpChar = /[\\^$.*+?()[\]{}|]/g;
+
+	/** Used to detect host constructors (Safari > 5). */
+	var reIsHostCtor = /^\[object .+?Constructor\]$/;
+
+	/** Used for built-in method references. */
+	var objectProto = Object.prototype;
+
+	/** Used to resolve the decompiled source of functions. */
+	var funcToString = Function.prototype.toString;
+
+	/** Used to check objects for own properties. */
+	var hasOwnProperty = objectProto.hasOwnProperty;
+
+	/** Used to detect if a method is native. */
+	var reIsNative = RegExp('^' +
+	  funcToString.call(hasOwnProperty).replace(reRegExpChar, '\\$&')
+	  .replace(/hasOwnProperty|(function).*?(?=\\\()| for .+?(?=\\\])/g, '$1.*?') + '$'
+	);
+
+	/**
+	 * Checks if `value` is a native function.
+	 *
+	 * @static
+	 * @memberOf _
+	 * @category Lang
+	 * @param {*} value The value to check.
+	 * @returns {boolean} Returns `true` if `value` is a native function, else `false`.
+	 * @example
+	 *
+	 * _.isNative(Array.prototype.push);
+	 * // => true
+	 *
+	 * _.isNative(_);
+	 * // => false
+	 */
+	function isNative(value) {
+	  if (value == null) {
+	    return false;
+	  }
+	  if (isFunction(value)) {
+	    return reIsNative.test(funcToString.call(value));
+	  }
+	  return isObjectLike(value) &&
+	    (isHostObject(value) ? reIsNative : reIsHostCtor).test(value);
+	}
+
+	module.exports = isNative;
+
+
+/***/ },
+/* 299 */
+/***/ function(module, exports) {
+
+	/**
+	 * Checks if `value` is a host object in IE < 9.
+	 *
+	 * @private
+	 * @param {*} value The value to check.
+	 * @returns {boolean} Returns `true` if `value` is a host object, else `false`.
+	 */
+	function isHostObject(value) {
+	  // Many host objects are `Object` objects that can coerce to strings
+	  // despite having improperly defined `toString` methods.
+	  var result = false;
+	  if (value != null && typeof value.toString != 'function') {
+	    try {
+	      result = !!(value + '');
+	    } catch (e) {}
+	  }
+	  return result;
+	}
+
+	module.exports = isHostObject;
+
+
+/***/ },
+/* 300 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var getNative = __webpack_require__(297),
+	    root = __webpack_require__(301);
+
+	/* Built-in method references that are verified to be native. */
+	var Map = getNative(root, 'Map');
+
+	module.exports = Map;
+
+
+/***/ },
+/* 301 */
+/***/ function(module, exports, __webpack_require__) {
+
+	/* WEBPACK VAR INJECTION */(function(module, global) {var checkGlobal = __webpack_require__(303);
+
+	/** Used to determine if values are of the language type `Object`. */
+	var objectTypes = {
+	  'function': true,
+	  'object': true
+	};
+
+	/** Detect free variable `exports`. */
+	var freeExports = (objectTypes[typeof exports] && exports && !exports.nodeType)
+	  ? exports
+	  : undefined;
+
+	/** Detect free variable `module`. */
+	var freeModule = (objectTypes[typeof module] && module && !module.nodeType)
+	  ? module
+	  : undefined;
+
+	/** Detect free variable `global` from Node.js. */
+	var freeGlobal = checkGlobal(freeExports && freeModule && typeof global == 'object' && global);
+
+	/** Detect free variable `self`. */
+	var freeSelf = checkGlobal(objectTypes[typeof self] && self);
+
+	/** Detect free variable `window`. */
+	var freeWindow = checkGlobal(objectTypes[typeof window] && window);
+
+	/** Detect `this` as the global object. */
+	var thisGlobal = checkGlobal(objectTypes[typeof this] && this);
+
+	/**
+	 * Used as a reference to the global object.
+	 *
+	 * The `this` value is used if it's the global object to avoid Greasemonkey's
+	 * restricted `window` object, otherwise the `window` object is used.
+	 */
+	var root = freeGlobal ||
+	  ((freeWindow !== (thisGlobal && thisGlobal.window)) && freeWindow) ||
+	    freeSelf || thisGlobal || Function('return this')();
+
+	module.exports = root;
+
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(302)(module), (function() { return this; }())))
+
+/***/ },
+/* 302 */
+/***/ function(module, exports) {
+
+	module.exports = function(module) {
+		if(!module.webpackPolyfill) {
+			module.deprecate = function() {};
+			module.paths = [];
+			// module.parent = undefined by default
+			module.children = [];
+			module.webpackPolyfill = 1;
+		}
+		return module;
+	}
+
+
+/***/ },
+/* 303 */
+/***/ function(module, exports) {
+
+	/**
+	 * Checks if `value` is a global object.
+	 *
+	 * @private
+	 * @param {*} value The value to check.
+	 * @returns {null|Object} Returns `value` if it's a global object, else `null`.
+	 */
+	function checkGlobal(value) {
+	  return (value && value.Object === Object) ? value : null;
+	}
+
+	module.exports = checkGlobal;
+
+
+/***/ },
+/* 304 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var Map = __webpack_require__(300),
+	    assocDelete = __webpack_require__(286),
+	    hashDelete = __webpack_require__(305),
+	    isKeyable = __webpack_require__(307);
+
+	/**
+	 * Removes `key` and its value from the map.
+	 *
+	 * @private
+	 * @name delete
+	 * @memberOf MapCache
+	 * @param {string} key The key of the value to remove.
+	 * @returns {boolean} Returns `true` if the entry was removed, else `false`.
+	 */
+	function mapDelete(key) {
+	  var data = this.__data__;
+	  if (isKeyable(key)) {
+	    return hashDelete(typeof key == 'string' ? data.string : data.hash, key);
+	  }
+	  return Map ? data.map['delete'](key) : assocDelete(data.map, key);
+	}
+
+	module.exports = mapDelete;
+
+
+/***/ },
+/* 305 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var hashHas = __webpack_require__(306);
+
+	/**
+	 * Removes `key` and its value from the hash.
+	 *
+	 * @private
+	 * @param {Object} hash The hash to modify.
+	 * @param {string} key The key of the value to remove.
+	 * @returns {boolean} Returns `true` if the entry was removed, else `false`.
+	 */
+	function hashDelete(hash, key) {
+	  return hashHas(hash, key) && delete hash[key];
+	}
+
+	module.exports = hashDelete;
+
+
+/***/ },
+/* 306 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var nativeCreate = __webpack_require__(296);
+
+	/** Used for built-in method references. */
+	var objectProto = Object.prototype;
+
+	/** Used to check objects for own properties. */
+	var hasOwnProperty = objectProto.hasOwnProperty;
+
+	/**
+	 * Checks if a hash value for `key` exists.
+	 *
+	 * @private
+	 * @param {Object} hash The hash to query.
+	 * @param {string} key The key of the entry to check.
+	 * @returns {boolean} Returns `true` if an entry for `key` exists, else `false`.
+	 */
+	function hashHas(hash, key) {
+	  return nativeCreate ? hash[key] !== undefined : hasOwnProperty.call(hash, key);
+	}
+
+	module.exports = hashHas;
+
+
+/***/ },
+/* 307 */
+/***/ function(module, exports) {
+
+	/**
+	 * Checks if `value` is suitable for use as unique object key.
+	 *
+	 * @private
+	 * @param {*} value The value to check.
+	 * @returns {boolean} Returns `true` if `value` is suitable, else `false`.
+	 */
+	function isKeyable(value) {
+	  var type = typeof value;
+	  return type == 'number' || type == 'boolean' ||
+	    (type == 'string' && value != '__proto__') || value == null;
+	}
+
+	module.exports = isKeyable;
+
+
+/***/ },
+/* 308 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var Map = __webpack_require__(300),
+	    assocGet = __webpack_require__(289),
+	    hashGet = __webpack_require__(309),
+	    isKeyable = __webpack_require__(307);
+
+	/**
+	 * Gets the map value for `key`.
+	 *
+	 * @private
+	 * @name get
+	 * @memberOf MapCache
+	 * @param {string} key The key of the value to get.
+	 * @returns {*} Returns the entry value.
+	 */
+	function mapGet(key) {
+	  var data = this.__data__;
+	  if (isKeyable(key)) {
+	    return hashGet(typeof key == 'string' ? data.string : data.hash, key);
+	  }
+	  return Map ? data.map.get(key) : assocGet(data.map, key);
+	}
+
+	module.exports = mapGet;
+
+
+/***/ },
+/* 309 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var nativeCreate = __webpack_require__(296);
+
+	/** Used to stand-in for `undefined` hash values. */
+	var HASH_UNDEFINED = '__lodash_hash_undefined__';
+
+	/** Used for built-in method references. */
+	var objectProto = Object.prototype;
+
+	/** Used to check objects for own properties. */
+	var hasOwnProperty = objectProto.hasOwnProperty;
+
+	/**
+	 * Gets the hash value for `key`.
+	 *
+	 * @private
+	 * @param {Object} hash The hash to query.
+	 * @param {string} key The key of the value to get.
+	 * @returns {*} Returns the entry value.
+	 */
+	function hashGet(hash, key) {
+	  if (nativeCreate) {
+	    var result = hash[key];
+	    return result === HASH_UNDEFINED ? undefined : result;
+	  }
+	  return hasOwnProperty.call(hash, key) ? hash[key] : undefined;
+	}
+
+	module.exports = hashGet;
+
+
+/***/ },
+/* 310 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var Map = __webpack_require__(300),
+	    assocHas = __webpack_require__(291),
+	    hashHas = __webpack_require__(306),
+	    isKeyable = __webpack_require__(307);
+
+	/**
+	 * Checks if a map value for `key` exists.
+	 *
+	 * @private
+	 * @name has
+	 * @memberOf MapCache
+	 * @param {string} key The key of the entry to check.
+	 * @returns {boolean} Returns `true` if an entry for `key` exists, else `false`.
+	 */
+	function mapHas(key) {
+	  var data = this.__data__;
+	  if (isKeyable(key)) {
+	    return hashHas(typeof key == 'string' ? data.string : data.hash, key);
+	  }
+	  return Map ? data.map.has(key) : assocHas(data.map, key);
+	}
+
+	module.exports = mapHas;
+
+
+/***/ },
+/* 311 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var Map = __webpack_require__(300),
+	    assocSet = __webpack_require__(312),
+	    hashSet = __webpack_require__(313),
+	    isKeyable = __webpack_require__(307);
+
+	/**
+	 * Sets the map `key` to `value`.
+	 *
+	 * @private
+	 * @name set
+	 * @memberOf MapCache
+	 * @param {string} key The key of the value to set.
+	 * @param {*} value The value to set.
+	 * @returns {Object} Returns the map cache object.
+	 */
+	function mapSet(key, value) {
+	  var data = this.__data__;
+	  if (isKeyable(key)) {
+	    hashSet(typeof key == 'string' ? data.string : data.hash, key, value);
+	  } else if (Map) {
+	    data.map.set(key, value);
+	  } else {
+	    assocSet(data.map, key, value);
+	  }
+	  return this;
+	}
+
+	module.exports = mapSet;
+
+
+/***/ },
+/* 312 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var assocIndexOf = __webpack_require__(287);
+
+	/**
+	 * Sets the associative array `key` to `value`.
+	 *
+	 * @private
+	 * @param {Array} array The array to modify.
+	 * @param {string} key The key of the value to set.
+	 * @param {*} value The value to set.
+	 */
+	function assocSet(array, key, value) {
+	  var index = assocIndexOf(array, key);
+	  if (index < 0) {
+	    array.push([key, value]);
+	  } else {
+	    array[index][1] = value;
+	  }
+	}
+
+	module.exports = assocSet;
+
+
+/***/ },
+/* 313 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var nativeCreate = __webpack_require__(296);
+
+	/** Used to stand-in for `undefined` hash values. */
+	var HASH_UNDEFINED = '__lodash_hash_undefined__';
+
+	/**
+	 * Sets the hash `key` to `value`.
+	 *
+	 * @private
+	 * @param {Object} hash The hash to modify.
+	 * @param {string} key The key of the value to set.
+	 * @param {*} value The value to set.
+	 */
+	function hashSet(hash, key, value) {
+	  hash[key] = (nativeCreate && value === undefined) ? HASH_UNDEFINED : value;
+	}
+
+	module.exports = hashSet;
+
+
+/***/ },
+/* 314 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var baseIsEqualDeep = __webpack_require__(315),
+	    isObject = __webpack_require__(236),
+	    isObjectLike = __webpack_require__(250);
+
+	/**
+	 * The base implementation of `_.isEqual` which supports partial comparisons
+	 * and tracks traversed objects.
+	 *
+	 * @private
+	 * @param {*} value The value to compare.
+	 * @param {*} other The other value to compare.
+	 * @param {Function} [customizer] The function to customize comparisons.
+	 * @param {boolean} [bitmask] The bitmask of comparison flags.
+	 *  The bitmask may be composed of the following flags:
+	 *     1 - Unordered comparison
+	 *     2 - Partial comparison
+	 * @param {Object} [stack] Tracks traversed `value` and `other` objects.
+	 * @returns {boolean} Returns `true` if the values are equivalent, else `false`.
+	 */
+	function baseIsEqual(value, other, customizer, bitmask, stack) {
+	  if (value === other) {
+	    return true;
+	  }
+	  if (value == null || other == null || (!isObject(value) && !isObjectLike(other))) {
+	    return value !== value && other !== other;
+	  }
+	  return baseIsEqualDeep(value, other, baseIsEqual, customizer, bitmask, stack);
+	}
+
+	module.exports = baseIsEqual;
+
+
+/***/ },
+/* 315 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var Stack = __webpack_require__(283),
+	    equalArrays = __webpack_require__(316),
+	    equalByTag = __webpack_require__(318),
+	    equalObjects = __webpack_require__(323),
+	    getTag = __webpack_require__(324),
+	    isArray = __webpack_require__(251),
+	    isHostObject = __webpack_require__(299),
+	    isTypedArray = __webpack_require__(327);
+
+	/** Used to compose bitmasks for comparison styles. */
+	var PARTIAL_COMPARE_FLAG = 2;
+
+	/** `Object#toString` result references. */
+	var argsTag = '[object Arguments]',
+	    arrayTag = '[object Array]',
+	    objectTag = '[object Object]';
+
+	/** Used for built-in method references. */
+	var objectProto = Object.prototype;
+
+	/** Used to check objects for own properties. */
+	var hasOwnProperty = objectProto.hasOwnProperty;
+
+	/**
+	 * A specialized version of `baseIsEqual` for arrays and objects which performs
+	 * deep comparisons and tracks traversed objects enabling objects with circular
+	 * references to be compared.
+	 *
+	 * @private
+	 * @param {Object} object The object to compare.
+	 * @param {Object} other The other object to compare.
+	 * @param {Function} equalFunc The function to determine equivalents of values.
+	 * @param {Function} [customizer] The function to customize comparisons.
+	 * @param {number} [bitmask] The bitmask of comparison flags. See `baseIsEqual` for more details.
+	 * @param {Object} [stack] Tracks traversed `object` and `other` objects.
+	 * @returns {boolean} Returns `true` if the objects are equivalent, else `false`.
+	 */
+	function baseIsEqualDeep(object, other, equalFunc, customizer, bitmask, stack) {
+	  var objIsArr = isArray(object),
+	      othIsArr = isArray(other),
+	      objTag = arrayTag,
+	      othTag = arrayTag;
+
+	  if (!objIsArr) {
+	    objTag = getTag(object);
+	    if (objTag == argsTag) {
+	      objTag = objectTag;
+	    } else if (objTag != objectTag) {
+	      objIsArr = isTypedArray(object);
+	    }
+	  }
+	  if (!othIsArr) {
+	    othTag = getTag(other);
+	    if (othTag == argsTag) {
+	      othTag = objectTag;
+	    } else if (othTag != objectTag) {
+	      othIsArr = isTypedArray(other);
+	    }
+	  }
+	  var objIsObj = objTag == objectTag && !isHostObject(object),
+	      othIsObj = othTag == objectTag && !isHostObject(other),
+	      isSameTag = objTag == othTag;
+
+	  if (isSameTag && !(objIsArr || objIsObj)) {
+	    return equalByTag(object, other, objTag, equalFunc, customizer, bitmask);
+	  }
+	  var isPartial = bitmask & PARTIAL_COMPARE_FLAG;
+	  if (!isPartial) {
+	    var objIsWrapped = objIsObj && hasOwnProperty.call(object, '__wrapped__'),
+	        othIsWrapped = othIsObj && hasOwnProperty.call(other, '__wrapped__');
+
+	    if (objIsWrapped || othIsWrapped) {
+	      return equalFunc(objIsWrapped ? object.value() : object, othIsWrapped ? other.value() : other, customizer, bitmask, stack);
+	    }
+	  }
+	  if (!isSameTag) {
+	    return false;
+	  }
+	  stack || (stack = new Stack);
+	  return (objIsArr ? equalArrays : equalObjects)(object, other, equalFunc, customizer, bitmask, stack);
+	}
+
+	module.exports = baseIsEqualDeep;
+
+
+/***/ },
+/* 316 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var arraySome = __webpack_require__(317);
+
+	/** Used to compose bitmasks for comparison styles. */
+	var UNORDERED_COMPARE_FLAG = 1,
+	    PARTIAL_COMPARE_FLAG = 2;
+
+	/**
+	 * A specialized version of `baseIsEqualDeep` for arrays with support for
+	 * partial deep comparisons.
+	 *
+	 * @private
+	 * @param {Array} array The array to compare.
+	 * @param {Array} other The other array to compare.
+	 * @param {Function} equalFunc The function to determine equivalents of values.
+	 * @param {Function} [customizer] The function to customize comparisons.
+	 * @param {number} [bitmask] The bitmask of comparison flags. See `baseIsEqual` for more details.
+	 * @param {Object} [stack] Tracks traversed `array` and `other` objects.
+	 * @returns {boolean} Returns `true` if the arrays are equivalent, else `false`.
+	 */
+	function equalArrays(array, other, equalFunc, customizer, bitmask, stack) {
+	  var index = -1,
+	      isPartial = bitmask & PARTIAL_COMPARE_FLAG,
+	      isUnordered = bitmask & UNORDERED_COMPARE_FLAG,
+	      arrLength = array.length,
+	      othLength = other.length;
+
+	  if (arrLength != othLength && !(isPartial && othLength > arrLength)) {
+	    return false;
+	  }
+	  // Assume cyclic values are equal.
+	  var stacked = stack.get(array);
+	  if (stacked) {
+	    return stacked == other;
+	  }
+	  var result = true;
+	  stack.set(array, other);
+
+	  // Ignore non-index properties.
+	  while (++index < arrLength) {
+	    var arrValue = array[index],
+	        othValue = other[index];
+
+	    if (customizer) {
+	      var compared = isPartial
+	        ? customizer(othValue, arrValue, index, other, array, stack)
+	        : customizer(arrValue, othValue, index, array, other, stack);
+	    }
+	    if (compared !== undefined) {
+	      if (compared) {
+	        continue;
+	      }
+	      result = false;
+	      break;
+	    }
+	    // Recursively compare arrays (susceptible to call stack limits).
+	    if (isUnordered) {
+	      if (!arraySome(other, function(othValue) {
+	            return arrValue === othValue || equalFunc(arrValue, othValue, customizer, bitmask, stack);
+	          })) {
+	        result = false;
+	        break;
+	      }
+	    } else if (!(arrValue === othValue || equalFunc(arrValue, othValue, customizer, bitmask, stack))) {
+	      result = false;
+	      break;
+	    }
+	  }
+	  stack['delete'](array);
+	  return result;
+	}
+
+	module.exports = equalArrays;
+
+
+/***/ },
+/* 317 */
+/***/ function(module, exports) {
+
+	/**
+	 * A specialized version of `_.some` for arrays without support for iteratee
+	 * shorthands.
+	 *
+	 * @private
+	 * @param {Array} array The array to iterate over.
+	 * @param {Function} predicate The function invoked per iteration.
+	 * @returns {boolean} Returns `true` if any element passes the predicate check, else `false`.
+	 */
+	function arraySome(array, predicate) {
+	  var index = -1,
+	      length = array.length;
+
+	  while (++index < length) {
+	    if (predicate(array[index], index, array)) {
+	      return true;
+	    }
+	  }
+	  return false;
+	}
+
+	module.exports = arraySome;
+
+
+/***/ },
+/* 318 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var Symbol = __webpack_require__(319),
+	    Uint8Array = __webpack_require__(320),
+	    mapToArray = __webpack_require__(321),
+	    setToArray = __webpack_require__(322);
+
+	/** Used to compose bitmasks for comparison styles. */
+	var UNORDERED_COMPARE_FLAG = 1,
+	    PARTIAL_COMPARE_FLAG = 2;
+
+	/** `Object#toString` result references. */
+	var boolTag = '[object Boolean]',
+	    dateTag = '[object Date]',
+	    errorTag = '[object Error]',
+	    mapTag = '[object Map]',
+	    numberTag = '[object Number]',
+	    regexpTag = '[object RegExp]',
+	    setTag = '[object Set]',
+	    stringTag = '[object String]',
+	    symbolTag = '[object Symbol]';
+
+	var arrayBufferTag = '[object ArrayBuffer]';
+
+	/** Used to convert symbols to primitives and strings. */
+	var symbolProto = Symbol ? Symbol.prototype : undefined,
+	    symbolValueOf = Symbol ? symbolProto.valueOf : undefined;
+
+	/**
+	 * A specialized version of `baseIsEqualDeep` for comparing objects of
+	 * the same `toStringTag`.
+	 *
+	 * **Note:** This function only supports comparing values with tags of
+	 * `Boolean`, `Date`, `Error`, `Number`, `RegExp`, or `String`.
+	 *
+	 * @private
+	 * @param {Object} object The object to compare.
+	 * @param {Object} other The other object to compare.
+	 * @param {string} tag The `toStringTag` of the objects to compare.
+	 * @param {Function} equalFunc The function to determine equivalents of values.
+	 * @param {Function} [customizer] The function to customize comparisons.
+	 * @param {number} [bitmask] The bitmask of comparison flags. See `baseIsEqual` for more details.
+	 * @returns {boolean} Returns `true` if the objects are equivalent, else `false`.
+	 */
+	function equalByTag(object, other, tag, equalFunc, customizer, bitmask) {
+	  switch (tag) {
+	    case arrayBufferTag:
+	      if ((object.byteLength != other.byteLength) ||
+	          !equalFunc(new Uint8Array(object), new Uint8Array(other))) {
+	        return false;
+	      }
+	      return true;
+
+	    case boolTag:
+	    case dateTag:
+	      // Coerce dates and booleans to numbers, dates to milliseconds and booleans
+	      // to `1` or `0` treating invalid dates coerced to `NaN` as not equal.
+	      return +object == +other;
+
+	    case errorTag:
+	      return object.name == other.name && object.message == other.message;
+
+	    case numberTag:
+	      // Treat `NaN` vs. `NaN` as equal.
+	      return (object != +object) ? other != +other : object == +other;
+
+	    case regexpTag:
+	    case stringTag:
+	      // Coerce regexes to strings and treat strings primitives and string
+	      // objects as equal. See https://es5.github.io/#x15.10.6.4 for more details.
+	      return object == (other + '');
+
+	    case mapTag:
+	      var convert = mapToArray;
+
+	    case setTag:
+	      var isPartial = bitmask & PARTIAL_COMPARE_FLAG;
+	      convert || (convert = setToArray);
+
+	      // Recursively compare objects (susceptible to call stack limits).
+	      return (isPartial || object.size == other.size) &&
+	        equalFunc(convert(object), convert(other), customizer, bitmask | UNORDERED_COMPARE_FLAG);
+
+	    case symbolTag:
+	      return !!Symbol && (symbolValueOf.call(object) == symbolValueOf.call(other));
+	  }
+	  return false;
+	}
+
+	module.exports = equalByTag;
+
+
+/***/ },
+/* 319 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var root = __webpack_require__(301);
+
+	/** Built-in value references. */
+	var Symbol = root.Symbol;
+
+	module.exports = Symbol;
+
+
+/***/ },
+/* 320 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var root = __webpack_require__(301);
+
+	/** Built-in value references. */
+	var Uint8Array = root.Uint8Array;
+
+	module.exports = Uint8Array;
+
+
+/***/ },
+/* 321 */
+/***/ function(module, exports) {
+
+	/**
+	 * Converts `map` to an array.
+	 *
+	 * @private
+	 * @param {Object} map The map to convert.
+	 * @returns {Array} Returns the converted array.
+	 */
+	function mapToArray(map) {
+	  var index = -1,
+	      result = Array(map.size);
+
+	  map.forEach(function(value, key) {
+	    result[++index] = [key, value];
+	  });
+	  return result;
+	}
+
+	module.exports = mapToArray;
+
+
+/***/ },
+/* 322 */
+/***/ function(module, exports) {
+
+	/**
+	 * Converts `set` to an array.
+	 *
+	 * @private
+	 * @param {Object} set The set to convert.
+	 * @returns {Array} Returns the converted array.
+	 */
+	function setToArray(set) {
+	  var index = -1,
+	      result = Array(set.size);
+
+	  set.forEach(function(value) {
+	    result[++index] = value;
+	  });
+	  return result;
+	}
+
+	module.exports = setToArray;
+
+
+/***/ },
+/* 323 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var baseHas = __webpack_require__(244),
+	    keys = __webpack_require__(243);
+
+	/** Used to compose bitmasks for comparison styles. */
+	var PARTIAL_COMPARE_FLAG = 2;
+
+	/**
+	 * A specialized version of `baseIsEqualDeep` for objects with support for
+	 * partial deep comparisons.
+	 *
+	 * @private
+	 * @param {Object} object The object to compare.
+	 * @param {Object} other The other object to compare.
+	 * @param {Function} equalFunc The function to determine equivalents of values.
+	 * @param {Function} [customizer] The function to customize comparisons.
+	 * @param {number} [bitmask] The bitmask of comparison flags. See `baseIsEqual` for more details.
+	 * @param {Object} [stack] Tracks traversed `object` and `other` objects.
+	 * @returns {boolean} Returns `true` if the objects are equivalent, else `false`.
+	 */
+	function equalObjects(object, other, equalFunc, customizer, bitmask, stack) {
+	  var isPartial = bitmask & PARTIAL_COMPARE_FLAG,
+	      objProps = keys(object),
+	      objLength = objProps.length,
+	      othProps = keys(other),
+	      othLength = othProps.length;
+
+	  if (objLength != othLength && !isPartial) {
+	    return false;
+	  }
+	  var index = objLength;
+	  while (index--) {
+	    var key = objProps[index];
+	    if (!(isPartial ? key in other : baseHas(other, key))) {
+	      return false;
+	    }
+	  }
+	  // Assume cyclic values are equal.
+	  var stacked = stack.get(object);
+	  if (stacked) {
+	    return stacked == other;
+	  }
+	  var result = true;
+	  stack.set(object, other);
+
+	  var skipCtor = isPartial;
+	  while (++index < objLength) {
+	    key = objProps[index];
+	    var objValue = object[key],
+	        othValue = other[key];
+
+	    if (customizer) {
+	      var compared = isPartial
+	        ? customizer(othValue, objValue, key, other, object, stack)
+	        : customizer(objValue, othValue, key, object, other, stack);
+	    }
+	    // Recursively compare objects (susceptible to call stack limits).
+	    if (!(compared === undefined
+	          ? (objValue === othValue || equalFunc(objValue, othValue, customizer, bitmask, stack))
+	          : compared
+	        )) {
+	      result = false;
+	      break;
+	    }
+	    skipCtor || (skipCtor = key == 'constructor');
+	  }
+	  if (result && !skipCtor) {
+	    var objCtor = object.constructor,
+	        othCtor = other.constructor;
+
+	    // Non `Object` object instances with different constructors are not equal.
+	    if (objCtor != othCtor &&
+	        ('constructor' in object && 'constructor' in other) &&
+	        !(typeof objCtor == 'function' && objCtor instanceof objCtor &&
+	          typeof othCtor == 'function' && othCtor instanceof othCtor)) {
+	      result = false;
+	    }
+	  }
+	  stack['delete'](object);
+	  return result;
+	}
+
+	module.exports = equalObjects;
+
+
+/***/ },
+/* 324 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var Map = __webpack_require__(300),
+	    Set = __webpack_require__(325),
+	    WeakMap = __webpack_require__(326);
+
+	/** `Object#toString` result references. */
+	var mapTag = '[object Map]',
+	    objectTag = '[object Object]',
+	    setTag = '[object Set]',
+	    weakMapTag = '[object WeakMap]';
+
+	/** Used for built-in method references. */
+	var objectProto = Object.prototype;
+
+	/** Used to resolve the decompiled source of functions. */
+	var funcToString = Function.prototype.toString;
+
+	/**
+	 * Used to resolve the [`toStringTag`](http://ecma-international.org/ecma-262/6.0/#sec-object.prototype.tostring)
+	 * of values.
+	 */
+	var objectToString = objectProto.toString;
+
+	/** Used to detect maps, sets, and weakmaps. */
+	var mapCtorString = Map ? funcToString.call(Map) : '',
+	    setCtorString = Set ? funcToString.call(Set) : '',
+	    weakMapCtorString = WeakMap ? funcToString.call(WeakMap) : '';
+
+	/**
+	 * Gets the `toStringTag` of `value`.
+	 *
+	 * @private
+	 * @param {*} value The value to query.
+	 * @returns {string} Returns the `toStringTag`.
+	 */
+	function getTag(value) {
+	  return objectToString.call(value);
+	}
+
+	// Fallback for IE 11 providing `toStringTag` values for maps, sets, and weakmaps.
+	if ((Map && getTag(new Map) != mapTag) ||
+	    (Set && getTag(new Set) != setTag) ||
+	    (WeakMap && getTag(new WeakMap) != weakMapTag)) {
+	  getTag = function(value) {
+	    var result = objectToString.call(value),
+	        Ctor = result == objectTag ? value.constructor : null,
+	        ctorString = typeof Ctor == 'function' ? funcToString.call(Ctor) : '';
+
+	    if (ctorString) {
+	      switch (ctorString) {
+	        case mapCtorString: return mapTag;
+	        case setCtorString: return setTag;
+	        case weakMapCtorString: return weakMapTag;
+	      }
+	    }
+	    return result;
+	  };
+	}
+
+	module.exports = getTag;
+
+
+/***/ },
+/* 325 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var getNative = __webpack_require__(297),
+	    root = __webpack_require__(301);
+
+	/* Built-in method references that are verified to be native. */
+	var Set = getNative(root, 'Set');
+
+	module.exports = Set;
+
+
+/***/ },
+/* 326 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var getNative = __webpack_require__(297),
+	    root = __webpack_require__(301);
+
+	/* Built-in method references that are verified to be native. */
+	var WeakMap = getNative(root, 'WeakMap');
+
+	module.exports = WeakMap;
+
+
+/***/ },
+/* 327 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var isLength = __webpack_require__(237),
+	    isObjectLike = __webpack_require__(250);
+
+	/** `Object#toString` result references. */
+	var argsTag = '[object Arguments]',
+	    arrayTag = '[object Array]',
+	    boolTag = '[object Boolean]',
+	    dateTag = '[object Date]',
+	    errorTag = '[object Error]',
+	    funcTag = '[object Function]',
+	    mapTag = '[object Map]',
+	    numberTag = '[object Number]',
+	    objectTag = '[object Object]',
+	    regexpTag = '[object RegExp]',
+	    setTag = '[object Set]',
+	    stringTag = '[object String]',
+	    weakMapTag = '[object WeakMap]';
+
+	var arrayBufferTag = '[object ArrayBuffer]',
+	    float32Tag = '[object Float32Array]',
+	    float64Tag = '[object Float64Array]',
+	    int8Tag = '[object Int8Array]',
+	    int16Tag = '[object Int16Array]',
+	    int32Tag = '[object Int32Array]',
+	    uint8Tag = '[object Uint8Array]',
+	    uint8ClampedTag = '[object Uint8ClampedArray]',
+	    uint16Tag = '[object Uint16Array]',
+	    uint32Tag = '[object Uint32Array]';
+
+	/** Used to identify `toStringTag` values of typed arrays. */
+	var typedArrayTags = {};
+	typedArrayTags[float32Tag] = typedArrayTags[float64Tag] =
+	typedArrayTags[int8Tag] = typedArrayTags[int16Tag] =
+	typedArrayTags[int32Tag] = typedArrayTags[uint8Tag] =
+	typedArrayTags[uint8ClampedTag] = typedArrayTags[uint16Tag] =
+	typedArrayTags[uint32Tag] = true;
+	typedArrayTags[argsTag] = typedArrayTags[arrayTag] =
+	typedArrayTags[arrayBufferTag] = typedArrayTags[boolTag] =
+	typedArrayTags[dateTag] = typedArrayTags[errorTag] =
+	typedArrayTags[funcTag] = typedArrayTags[mapTag] =
+	typedArrayTags[numberTag] = typedArrayTags[objectTag] =
+	typedArrayTags[regexpTag] = typedArrayTags[setTag] =
+	typedArrayTags[stringTag] = typedArrayTags[weakMapTag] = false;
+
+	/** Used for built-in method references. */
+	var objectProto = Object.prototype;
+
+	/**
+	 * Used to resolve the [`toStringTag`](http://ecma-international.org/ecma-262/6.0/#sec-object.prototype.tostring)
+	 * of values.
+	 */
+	var objectToString = objectProto.toString;
+
+	/**
+	 * Checks if `value` is classified as a typed array.
+	 *
+	 * @static
+	 * @memberOf _
+	 * @category Lang
+	 * @param {*} value The value to check.
+	 * @returns {boolean} Returns `true` if `value` is correctly classified, else `false`.
+	 * @example
+	 *
+	 * _.isTypedArray(new Uint8Array);
+	 * // => true
+	 *
+	 * _.isTypedArray([]);
+	 * // => false
+	 */
+	function isTypedArray(value) {
+	  return isObjectLike(value) &&
+	    isLength(value.length) && !!typedArrayTags[objectToString.call(value)];
+	}
+
+	module.exports = isTypedArray;
+
+
+/***/ },
+/* 328 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var isStrictComparable = __webpack_require__(329),
+	    toPairs = __webpack_require__(330);
+
+	/**
+	 * Gets the property names, values, and compare flags of `object`.
+	 *
+	 * @private
+	 * @param {Object} object The object to query.
+	 * @returns {Array} Returns the match data of `object`.
+	 */
+	function getMatchData(object) {
+	  var result = toPairs(object),
+	      length = result.length;
+
+	  while (length--) {
+	    result[length][2] = isStrictComparable(result[length][1]);
+	  }
+	  return result;
+	}
+
+	module.exports = getMatchData;
+
+
+/***/ },
+/* 329 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var isObject = __webpack_require__(236);
+
+	/**
+	 * Checks if `value` is suitable for strict equality comparisons, i.e. `===`.
+	 *
+	 * @private
+	 * @param {*} value The value to check.
+	 * @returns {boolean} Returns `true` if `value` if suitable for strict
+	 *  equality comparisons, else `false`.
+	 */
+	function isStrictComparable(value) {
+	  return value === value && !isObject(value);
+	}
+
+	module.exports = isStrictComparable;
+
+
+/***/ },
+/* 330 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var baseToPairs = __webpack_require__(331),
+	    keys = __webpack_require__(243);
+
+	/**
+	 * Creates an array of own enumerable key-value pairs for `object` which
+	 * can be consumed by `_.fromPairs`.
+	 *
+	 * @static
+	 * @memberOf _
+	 * @category Object
+	 * @param {Object} object The object to query.
+	 * @returns {Array} Returns the new array of key-value pairs.
+	 * @example
+	 *
+	 * function Foo() {
+	 *   this.a = 1;
+	 *   this.b = 2;
+	 * }
+	 *
+	 * Foo.prototype.c = 3;
+	 *
+	 * _.toPairs(new Foo);
+	 * // => [['a', 1], ['b', 2]] (iteration order is not guaranteed)
+	 */
+	function toPairs(object) {
+	  return baseToPairs(object, keys(object));
+	}
+
+	module.exports = toPairs;
+
+
+/***/ },
+/* 331 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var arrayMap = __webpack_require__(332);
+
+	/**
+	 * The base implementation of `_.toPairs` and `_.toPairsIn` which creates an array
+	 * of key-value pairs for `object` corresponding to the property names of `props`.
+	 *
+	 * @private
+	 * @param {Object} object The object to query.
+	 * @param {Array} props The property names to get values for.
+	 * @returns {Object} Returns the new array of key-value pairs.
+	 */
+	function baseToPairs(object, props) {
+	  return arrayMap(props, function(key) {
+	    return [key, object[key]];
+	  });
+	}
+
+	module.exports = baseToPairs;
+
+
+/***/ },
+/* 332 */
+/***/ function(module, exports) {
+
+	/**
+	 * A specialized version of `_.map` for arrays without support for iteratee
+	 * shorthands.
+	 *
+	 * @private
+	 * @param {Array} array The array to iterate over.
+	 * @param {Function} iteratee The function invoked per iteration.
+	 * @returns {Array} Returns the new mapped array.
+	 */
+	function arrayMap(array, iteratee) {
+	  var index = -1,
+	      length = array.length,
+	      result = Array(length);
+
+	  while (++index < length) {
+	    result[index] = iteratee(array[index], index, array);
+	  }
+	  return result;
+	}
+
+	module.exports = arrayMap;
+
+
+/***/ },
+/* 333 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var baseIsEqual = __webpack_require__(314),
+	    get = __webpack_require__(334),
+	    hasIn = __webpack_require__(341);
+
+	/** Used to compose bitmasks for comparison styles. */
+	var UNORDERED_COMPARE_FLAG = 1,
+	    PARTIAL_COMPARE_FLAG = 2;
+
+	/**
+	 * The base implementation of `_.matchesProperty` which doesn't clone `srcValue`.
+	 *
+	 * @private
+	 * @param {string} path The path of the property to get.
+	 * @param {*} srcValue The value to match.
+	 * @returns {Function} Returns the new function.
+	 */
+	function baseMatchesProperty(path, srcValue) {
+	  return function(object) {
+	    var objValue = get(object, path);
+	    return (objValue === undefined && objValue === srcValue)
+	      ? hasIn(object, path)
+	      : baseIsEqual(srcValue, objValue, undefined, UNORDERED_COMPARE_FLAG | PARTIAL_COMPARE_FLAG);
+	  };
+	}
+
+	module.exports = baseMatchesProperty;
+
+
+/***/ },
+/* 334 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var baseGet = __webpack_require__(335);
+
+	/**
+	 * Gets the value at `path` of `object`. If the resolved value is
+	 * `undefined` the `defaultValue` is used in its place.
+	 *
+	 * @static
+	 * @memberOf _
+	 * @category Object
+	 * @param {Object} object The object to query.
+	 * @param {Array|string} path The path of the property to get.
+	 * @param {*} [defaultValue] The value returned if the resolved value is `undefined`.
+	 * @returns {*} Returns the resolved value.
+	 * @example
+	 *
+	 * var object = { 'a': [{ 'b': { 'c': 3 } }] };
+	 *
+	 * _.get(object, 'a[0].b.c');
+	 * // => 3
+	 *
+	 * _.get(object, ['a', '0', 'b', 'c']);
+	 * // => 3
+	 *
+	 * _.get(object, 'a.b.c', 'default');
+	 * // => 'default'
+	 */
+	function get(object, path, defaultValue) {
+	  var result = object == null ? undefined : baseGet(object, path);
+	  return result === undefined ? defaultValue : result;
+	}
+
+	module.exports = get;
+
+
+/***/ },
+/* 335 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var baseCastPath = __webpack_require__(336),
+	    isKey = __webpack_require__(340);
+
+	/**
+	 * The base implementation of `_.get` without support for default values.
+	 *
+	 * @private
+	 * @param {Object} object The object to query.
+	 * @param {Array|string} path The path of the property to get.
+	 * @returns {*} Returns the resolved value.
+	 */
+	function baseGet(object, path) {
+	  path = isKey(path, object) ? [path + ''] : baseCastPath(path);
+
+	  var index = 0,
+	      length = path.length;
+
+	  while (object != null && index < length) {
+	    object = object[path[index++]];
+	  }
+	  return (index && index == length) ? object : undefined;
+	}
+
+	module.exports = baseGet;
+
+
+/***/ },
+/* 336 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var isArray = __webpack_require__(251),
+	    stringToPath = __webpack_require__(337);
+
+	/**
+	 * Casts `value` to a path array if it's not one.
+	 *
+	 * @private
+	 * @param {*} value The value to inspect.
+	 * @returns {Array} Returns the cast property path array.
+	 */
+	function baseCastPath(value) {
+	  return isArray(value) ? value : stringToPath(value);
+	}
+
+	module.exports = baseCastPath;
+
+
+/***/ },
+/* 337 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var toString = __webpack_require__(338);
+
+	/** Used to match property names within property paths. */
+	var rePropName = /[^.[\]]+|\[(?:(-?\d+(?:\.\d+)?)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]/g;
+
+	/** Used to match backslashes in property paths. */
+	var reEscapeChar = /\\(\\)?/g;
+
+	/**
+	 * Converts `string` to a property path array.
+	 *
+	 * @private
+	 * @param {string} string The string to convert.
+	 * @returns {Array} Returns the property path array.
+	 */
+	function stringToPath(string) {
+	  var result = [];
+	  toString(string).replace(rePropName, function(match, number, quote, string) {
+	    result.push(quote ? string.replace(reEscapeChar, '$1') : (number || match));
+	  });
+	  return result;
+	}
+
+	module.exports = stringToPath;
+
+
+/***/ },
+/* 338 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var Symbol = __webpack_require__(319),
+	    isSymbol = __webpack_require__(339);
+
+	/** Used as references for various `Number` constants. */
+	var INFINITY = 1 / 0;
+
+	/** Used to convert symbols to primitives and strings. */
+	var symbolProto = Symbol ? Symbol.prototype : undefined,
+	    symbolToString = Symbol ? symbolProto.toString : undefined;
+
+	/**
+	 * Converts `value` to a string if it's not one. An empty string is returned
+	 * for `null` and `undefined` values. The sign of `-0` is preserved.
+	 *
+	 * @static
+	 * @memberOf _
+	 * @category Lang
+	 * @param {*} value The value to process.
+	 * @returns {string} Returns the string.
+	 * @example
+	 *
+	 * _.toString(null);
+	 * // => ''
+	 *
+	 * _.toString(-0);
+	 * // => '-0'
+	 *
+	 * _.toString([1, 2, 3]);
+	 * // => '1,2,3'
+	 */
+	function toString(value) {
+	  // Exit early for strings to avoid a performance hit in some environments.
+	  if (typeof value == 'string') {
+	    return value;
+	  }
+	  if (value == null) {
+	    return '';
+	  }
+	  if (isSymbol(value)) {
+	    return Symbol ? symbolToString.call(value) : '';
+	  }
+	  var result = (value + '');
+	  return (result == '0' && (1 / value) == -INFINITY) ? '-0' : result;
+	}
+
+	module.exports = toString;
+
+
+/***/ },
+/* 339 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var isObjectLike = __webpack_require__(250);
+
+	/** `Object#toString` result references. */
+	var symbolTag = '[object Symbol]';
+
+	/** Used for built-in method references. */
+	var objectProto = Object.prototype;
+
+	/**
+	 * Used to resolve the [`toStringTag`](http://ecma-international.org/ecma-262/6.0/#sec-object.prototype.tostring)
+	 * of values.
+	 */
+	var objectToString = objectProto.toString;
+
+	/**
+	 * Checks if `value` is classified as a `Symbol` primitive or object.
+	 *
+	 * @static
+	 * @memberOf _
+	 * @category Lang
+	 * @param {*} value The value to check.
+	 * @returns {boolean} Returns `true` if `value` is correctly classified, else `false`.
+	 * @example
+	 *
+	 * _.isSymbol(Symbol.iterator);
+	 * // => true
+	 *
+	 * _.isSymbol('abc');
+	 * // => false
+	 */
+	function isSymbol(value) {
+	  return typeof value == 'symbol' ||
+	    (isObjectLike(value) && objectToString.call(value) == symbolTag);
+	}
+
+	module.exports = isSymbol;
+
+
+/***/ },
+/* 340 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var isArray = __webpack_require__(251);
+
+	/** Used to match property names within property paths. */
+	var reIsDeepProp = /\.|\[(?:[^[\]]*|(["'])(?:(?!\1)[^\\]|\\.)*?\1)\]/,
+	    reIsPlainProp = /^\w*$/;
+
+	/**
+	 * Checks if `value` is a property name and not a property path.
+	 *
+	 * @private
+	 * @param {*} value The value to check.
+	 * @param {Object} [object] The object to query keys on.
+	 * @returns {boolean} Returns `true` if `value` is a property name, else `false`.
+	 */
+	function isKey(value, object) {
+	  if (typeof value == 'number') {
+	    return true;
+	  }
+	  return !isArray(value) &&
+	    (reIsPlainProp.test(value) || !reIsDeepProp.test(value) ||
+	      (object != null && value in Object(object)));
+	}
+
+	module.exports = isKey;
+
+
+/***/ },
+/* 341 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var baseHasIn = __webpack_require__(342),
+	    hasPath = __webpack_require__(343);
+
+	/**
+	 * Checks if `path` is a direct or inherited property of `object`.
+	 *
+	 * @static
+	 * @memberOf _
+	 * @category Object
+	 * @param {Object} object The object to query.
+	 * @param {Array|string} path The path to check.
+	 * @returns {boolean} Returns `true` if `path` exists, else `false`.
+	 * @example
+	 *
+	 * var object = _.create({ 'a': _.create({ 'b': _.create({ 'c': 3 }) }) });
+	 *
+	 * _.hasIn(object, 'a');
+	 * // => true
+	 *
+	 * _.hasIn(object, 'a.b.c');
+	 * // => true
+	 *
+	 * _.hasIn(object, ['a', 'b', 'c']);
+	 * // => true
+	 *
+	 * _.hasIn(object, 'b');
+	 * // => false
+	 */
+	function hasIn(object, path) {
+	  return hasPath(object, path, baseHasIn);
+	}
+
+	module.exports = hasIn;
+
+
+/***/ },
+/* 342 */
+/***/ function(module, exports) {
+
+	/**
+	 * The base implementation of `_.hasIn` without support for deep paths.
+	 *
+	 * @private
+	 * @param {Object} object The object to query.
+	 * @param {Array|string} key The key to check.
+	 * @returns {boolean} Returns `true` if `key` exists, else `false`.
+	 */
+	function baseHasIn(object, key) {
+	  return key in Object(object);
+	}
+
+	module.exports = baseHasIn;
+
+
+/***/ },
+/* 343 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var baseCastPath = __webpack_require__(336),
+	    isArguments = __webpack_require__(248),
+	    isArray = __webpack_require__(251),
+	    isIndex = __webpack_require__(238),
+	    isKey = __webpack_require__(340),
+	    isLength = __webpack_require__(237),
+	    isString = __webpack_require__(252),
+	    last = __webpack_require__(344),
+	    parent = __webpack_require__(345);
+
+	/**
+	 * Checks if `path` exists on `object`.
+	 *
+	 * @private
+	 * @param {Object} object The object to query.
+	 * @param {Array|string} path The path to check.
+	 * @param {Function} hasFunc The function to check properties.
+	 * @returns {boolean} Returns `true` if `path` exists, else `false`.
+	 */
+	function hasPath(object, path, hasFunc) {
+	  if (object == null) {
+	    return false;
+	  }
+	  var result = hasFunc(object, path);
+	  if (!result && !isKey(path)) {
+	    path = baseCastPath(path);
+	    object = parent(object, path);
+	    if (object != null) {
+	      path = last(path);
+	      result = hasFunc(object, path);
+	    }
+	  }
+	  var length = object ? object.length : undefined;
+	  return result || (
+	    !!length && isLength(length) && isIndex(path, length) &&
+	    (isArray(object) || isString(object) || isArguments(object))
+	  );
+	}
+
+	module.exports = hasPath;
+
+
+/***/ },
+/* 344 */
+/***/ function(module, exports) {
+
+	/**
+	 * Gets the last element of `array`.
+	 *
+	 * @static
+	 * @memberOf _
+	 * @category Array
+	 * @param {Array} array The array to query.
+	 * @returns {*} Returns the last element of `array`.
+	 * @example
+	 *
+	 * _.last([1, 2, 3]);
+	 * // => 3
+	 */
+	function last(array) {
+	  var length = array ? array.length : 0;
+	  return length ? array[length - 1] : undefined;
+	}
+
+	module.exports = last;
+
+
+/***/ },
+/* 345 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var baseSlice = __webpack_require__(346),
+	    get = __webpack_require__(334);
+
+	/**
+	 * Gets the parent value at `path` of `object`.
+	 *
+	 * @private
+	 * @param {Object} object The object to query.
+	 * @param {Array} path The path to get the parent value of.
+	 * @returns {*} Returns the parent value.
+	 */
+	function parent(object, path) {
+	  return path.length == 1 ? object : get(object, baseSlice(path, 0, -1));
+	}
+
+	module.exports = parent;
+
+
+/***/ },
+/* 346 */
+/***/ function(module, exports) {
+
+	/**
+	 * The base implementation of `_.slice` without an iteratee call guard.
+	 *
+	 * @private
+	 * @param {Array} array The array to slice.
+	 * @param {number} [start=0] The start position.
+	 * @param {number} [end=array.length] The end position.
+	 * @returns {Array} Returns the slice of `array`.
+	 */
+	function baseSlice(array, start, end) {
+	  var index = -1,
+	      length = array.length;
+
+	  if (start < 0) {
+	    start = -start > length ? 0 : (length + start);
+	  }
+	  end = end > length ? length : end;
+	  if (end < 0) {
+	    end += length;
+	  }
+	  length = start > end ? 0 : ((end - start) >>> 0);
+	  start >>>= 0;
+
+	  var result = Array(length);
+	  while (++index < length) {
+	    result[index] = array[index + start];
+	  }
+	  return result;
+	}
+
+	module.exports = baseSlice;
+
+
+/***/ },
+/* 347 */
+/***/ function(module, exports) {
+
+	/**
+	 * This method returns the first argument given to it.
+	 *
+	 * @static
+	 * @memberOf _
+	 * @category Util
+	 * @param {*} value Any value.
+	 * @returns {*} Returns `value`.
+	 * @example
+	 *
+	 * var object = { 'user': 'fred' };
+	 *
+	 * _.identity(object) === object;
+	 * // => true
+	 */
+	function identity(value) {
+	  return value;
+	}
+
+	module.exports = identity;
+
+
+/***/ },
+/* 348 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var baseProperty = __webpack_require__(234),
+	    basePropertyDeep = __webpack_require__(349),
+	    isKey = __webpack_require__(340);
+
+	/**
+	 * Creates a function that returns the value at `path` of a given object.
+	 *
+	 * @static
+	 * @memberOf _
+	 * @category Util
+	 * @param {Array|string} path The path of the property to get.
+	 * @returns {Function} Returns the new function.
+	 * @example
+	 *
+	 * var objects = [
+	 *   { 'a': { 'b': { 'c': 2 } } },
+	 *   { 'a': { 'b': { 'c': 1 } } }
+	 * ];
+	 *
+	 * _.map(objects, _.property('a.b.c'));
+	 * // => [2, 1]
+	 *
+	 * _.map(_.sortBy(objects, _.property(['a', 'b', 'c'])), 'a.b.c');
+	 * // => [1, 2]
+	 */
+	function property(path) {
+	  return isKey(path) ? baseProperty(path) : basePropertyDeep(path);
+	}
+
+	module.exports = property;
+
+
+/***/ },
+/* 349 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var baseGet = __webpack_require__(335);
+
+	/**
+	 * A specialized version of `baseProperty` which supports deep paths.
+	 *
+	 * @private
+	 * @param {Array|string} path The path of the property to get.
+	 * @returns {Function} Returns the new function.
+	 */
+	function basePropertyDeep(path) {
+	  return function(object) {
+	    return baseGet(object, path);
+	  };
+	}
+
+	module.exports = basePropertyDeep;
+
+
+/***/ },
+/* 350 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var arrayFilter = __webpack_require__(351),
+	    baseFilter = __webpack_require__(352),
+	    baseIteratee = __webpack_require__(280),
+	    isArray = __webpack_require__(251);
+
+	/**
+	 * Iterates over elements of `collection`, returning an array of all elements
+	 * `predicate` returns truthy for. The predicate is invoked with three arguments:
+	 * (value, index|key, collection).
+	 *
+	 * @static
+	 * @memberOf _
+	 * @category Collection
+	 * @param {Array|Object} collection The collection to iterate over.
+	 * @param {Function|Object|string} [predicate=_.identity] The function invoked per iteration.
+	 * @returns {Array} Returns the new filtered array.
+	 * @example
+	 *
+	 * var users = [
+	 *   { 'user': 'barney', 'age': 36, 'active': true },
+	 *   { 'user': 'fred',   'age': 40, 'active': false }
+	 * ];
+	 *
+	 * _.filter(users, function(o) { return !o.active; });
+	 * // => objects for ['fred']
+	 *
+	 * // The `_.matches` iteratee shorthand.
+	 * _.filter(users, { 'age': 36, 'active': true });
+	 * // => objects for ['barney']
+	 *
+	 * // The `_.matchesProperty` iteratee shorthand.
+	 * _.filter(users, ['active', false]);
+	 * // => objects for ['fred']
+	 *
+	 * // The `_.property` iteratee shorthand.
+	 * _.filter(users, 'active');
+	 * // => objects for ['barney']
+	 */
+	function filter(collection, predicate) {
+	  var func = isArray(collection) ? arrayFilter : baseFilter;
+	  return func(collection, baseIteratee(predicate, 3));
+	}
+
+	module.exports = filter;
+
+
+/***/ },
+/* 351 */
+/***/ function(module, exports) {
+
+	/**
+	 * A specialized version of `_.filter` for arrays without support for
+	 * iteratee shorthands.
+	 *
+	 * @private
+	 * @param {Array} array The array to iterate over.
+	 * @param {Function} predicate The function invoked per iteration.
+	 * @returns {Array} Returns the new filtered array.
+	 */
+	function arrayFilter(array, predicate) {
+	  var index = -1,
+	      length = array.length,
+	      resIndex = -1,
+	      result = [];
+
+	  while (++index < length) {
+	    var value = array[index];
+	    if (predicate(value, index, array)) {
+	      result[++resIndex] = value;
+	    }
+	  }
+	  return result;
+	}
+
+	module.exports = arrayFilter;
+
+
+/***/ },
+/* 352 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var baseEach = __webpack_require__(273);
+
+	/**
+	 * The base implementation of `_.filter` without support for iteratee shorthands.
+	 *
+	 * @private
+	 * @param {Array|Object} collection The collection to iterate over.
+	 * @param {Function} predicate The function invoked per iteration.
+	 * @returns {Array} Returns the new filtered array.
+	 */
+	function baseFilter(collection, predicate) {
+	  var result = [];
+	  baseEach(collection, function(value, index, collection) {
+	    if (predicate(value, index, collection)) {
+	      result.push(value);
+	    }
+	  });
+	  return result;
+	}
+
+	module.exports = baseFilter;
+
+
+/***/ },
+/* 353 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var baseFindIndex = __webpack_require__(279),
+	    baseIteratee = __webpack_require__(280);
+
+	/**
+	 * This method is like `_.find` except that it returns the index of the first
+	 * element `predicate` returns truthy for instead of the element itself.
+	 *
+	 * @static
+	 * @memberOf _
+	 * @category Array
+	 * @param {Array} array The array to search.
+	 * @param {Function|Object|string} [predicate=_.identity] The function invoked per iteration.
+	 * @returns {number} Returns the index of the found element, else `-1`.
+	 * @example
+	 *
+	 * var users = [
+	 *   { 'user': 'barney',  'active': false },
+	 *   { 'user': 'fred',    'active': false },
+	 *   { 'user': 'pebbles', 'active': true }
+	 * ];
+	 *
+	 * _.findIndex(users, function(o) { return o.user == 'barney'; });
+	 * // => 0
+	 *
+	 * // The `_.matches` iteratee shorthand.
+	 * _.findIndex(users, { 'user': 'fred', 'active': false });
+	 * // => 1
+	 *
+	 * // The `_.matchesProperty` iteratee shorthand.
+	 * _.findIndex(users, ['active', false]);
+	 * // => 0
+	 *
+	 * // The `_.property` iteratee shorthand.
+	 * _.findIndex(users, 'active');
+	 * // => 2
+	 */
+	function findIndex(array, predicate) {
+	  return (array && array.length)
+	    ? baseFindIndex(array, baseIteratee(predicate, 3))
+	    : -1;
+	}
+
+	module.exports = findIndex;
+
+
+/***/ },
+/* 354 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var arrayMap = __webpack_require__(332),
+	    baseIteratee = __webpack_require__(280),
+	    baseMap = __webpack_require__(355),
+	    isArray = __webpack_require__(251);
+
+	/**
+	 * Creates an array of values by running each element in `collection` through
+	 * `iteratee`. The iteratee is invoked with three arguments:
+	 * (value, index|key, collection).
+	 *
+	 * Many lodash methods are guarded to work as iteratees for methods like
+	 * `_.every`, `_.filter`, `_.map`, `_.mapValues`, `_.reject`, and `_.some`.
+	 *
+	 * The guarded methods are:
+	 * `ary`, `curry`, `curryRight`, `drop`, `dropRight`, `every`, `fill`,
+	 * `invert`, `parseInt`, `random`, `range`, `rangeRight`, `slice`, `some`,
+	 * `sortBy`, `take`, `takeRight`, `template`, `trim`, `trimEnd`, `trimStart`,
+	 * and `words`
+	 *
+	 * @static
+	 * @memberOf _
+	 * @category Collection
+	 * @param {Array|Object} collection The collection to iterate over.
+	 * @param {Function|Object|string} [iteratee=_.identity] The function invoked per iteration.
+	 * @returns {Array} Returns the new mapped array.
+	 * @example
+	 *
+	 * function square(n) {
+	 *   return n * n;
+	 * }
+	 *
+	 * _.map([4, 8], square);
+	 * // => [16, 64]
+	 *
+	 * _.map({ 'a': 4, 'b': 8 }, square);
+	 * // => [16, 64] (iteration order is not guaranteed)
+	 *
+	 * var users = [
+	 *   { 'user': 'barney' },
+	 *   { 'user': 'fred' }
+	 * ];
+	 *
+	 * // The `_.property` iteratee shorthand.
+	 * _.map(users, 'user');
+	 * // => ['barney', 'fred']
+	 */
+	function map(collection, iteratee) {
+	  var func = isArray(collection) ? arrayMap : baseMap;
+	  return func(collection, baseIteratee(iteratee, 3));
+	}
+
+	module.exports = map;
+
+
+/***/ },
+/* 355 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var baseEach = __webpack_require__(273),
+	    isArrayLike = __webpack_require__(232);
+
+	/**
+	 * The base implementation of `_.map` without support for iteratee shorthands.
+	 *
+	 * @private
+	 * @param {Array|Object} collection The collection to iterate over.
+	 * @param {Function} iteratee The function invoked per iteration.
+	 * @returns {Array} Returns the new mapped array.
+	 */
+	function baseMap(collection, iteratee) {
+	  var index = -1,
+	      result = isArrayLike(collection) ? Array(collection.length) : [];
+
+	  baseEach(collection, function(value, key, collection) {
+	    result[++index] = iteratee(value, key, collection);
+	  });
+	  return result;
+	}
+
+	module.exports = baseMap;
+
+
+/***/ },
+/* 356 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var baseCastPath = __webpack_require__(336),
+	    get = __webpack_require__(334),
+	    isFunction = __webpack_require__(235),
+	    isKey = __webpack_require__(340),
+	    parent = __webpack_require__(345);
+
+	/**
+	 * This method is like `_.get` except that if the resolved value is a function
+	 * it's invoked with the `this` binding of its parent object and its result
+	 * is returned.
+	 *
+	 * @static
+	 * @memberOf _
+	 * @category Object
+	 * @param {Object} object The object to query.
+	 * @param {Array|string} path The path of the property to resolve.
+	 * @param {*} [defaultValue] The value returned if the resolved value is `undefined`.
+	 * @returns {*} Returns the resolved value.
+	 * @example
+	 *
+	 * var object = { 'a': [{ 'b': { 'c1': 3, 'c2': _.constant(4) } }] };
+	 *
+	 * _.result(object, 'a[0].b.c1');
+	 * // => 3
+	 *
+	 * _.result(object, 'a[0].b.c2');
+	 * // => 4
+	 *
+	 * _.result(object, 'a[0].b.c3', 'default');
+	 * // => 'default'
+	 *
+	 * _.result(object, 'a[0].b.c3', _.constant('default'));
+	 * // => 'default'
+	 */
+	function result(object, path, defaultValue) {
+	  if (!isKey(path, object)) {
+	    path = baseCastPath(path);
+	    var result = get(object, path);
+	    object = parent(object, path);
+	  } else {
+	    result = object == null ? undefined : object[path];
+	  }
+	  if (result === undefined) {
+	    result = defaultValue;
+	  }
+	  return isFunction(result) ? result.call(object) : result;
+	}
+
+	module.exports = result;
+
+
+/***/ },
+/* 357 */
+/***/ function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	/** @ssr-ready **/
+
+	/**
+	 * External Dependencies
+	 */
+	var React = __webpack_require__(4),
+	    classNames = __webpack_require__(254);
+
+	/**
+	 * Internal dependencies
+	 */
+	var Count = __webpack_require__(358);
+
+	var SelectDropdownItem = React.createClass({
+		displayName: 'SelectDropdownItem',
+
+		propTypes: {
+			children: React.PropTypes.string.isRequired,
+			path: React.PropTypes.string,
+			selected: React.PropTypes.bool,
+			onClick: React.PropTypes.func,
+			count: React.PropTypes.number
+		},
+
+		getDefaultProps: function getDefaultProps() {
+			return {
+				selected: false
+			};
+		},
+
+		render: function render() {
+			var optionClassName = classNames(this.props.className, {
+				'dops-select-dropdown__item': true,
+				'is-selected': this.props.selected,
+				'is-disabled': this.props.disabled
+			});
+
+			return React.createElement(
+				'li',
+				{ className: 'dops-select-dropdown__option' },
+				React.createElement(
+					'a',
+					{
+						ref: 'itemLink',
+						href: this.props.path,
+						className: optionClassName,
+						onClick: this.props.disabled ? null : this.props.onClick,
+						'data-bold-text': this.props.value || this.props.children,
+						role: 'menuitem',
+						tabIndex: 0,
+						'aria-selected': this.props.selected },
+					React.createElement(
+						'span',
+						{ className: 'dops-select-dropdown__item-text' },
+						this.props.children,
+						'number' === typeof this.props.count && React.createElement(Count, { count: this.props.count })
+					)
+				)
+			);
+		}
+	});
+
+	module.exports = SelectDropdownItem;
+
+/***/ },
+/* 358 */
+/***/ function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+		value: true
+	});
+
+	var _react = __webpack_require__(4);
+
+	var _react2 = _interopRequireDefault(_react);
+
+	var _mixin = __webpack_require__(359);
+
+	var _mixin2 = _interopRequireDefault(_mixin);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	/** @ssr-ready **/
+
+	/**
+	 * External dependencies
+	 */
+	__webpack_require__(362);
+
+	exports.default = _react2.default.createClass({
+
+		displayName: 'Count',
+
+		mixins: [_mixin2.default],
+
+		propTypes: {
+			count: _react2.default.PropTypes.number.isRequired
+		},
+
+		render: function render() {
+			return _react2.default.createElement(
+				'span',
+				{ className: 'dops-count' },
+				this.numberFormat(this.props.count)
+			);
+		}
+	});
+	module.exports = exports['default'];
+
+/***/ },
+/* 359 */
+/***/ function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	exports.__esModule = true;
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+	var _function = __webpack_require__(360);
+
+	var _function2 = _interopRequireDefault(_function);
+
+	exports['default'] = {
+	  shouldComponentUpdate: _function2['default']
+	};
+	module.exports = exports['default'];
+
+/***/ },
+/* 360 */
+/***/ function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	exports.__esModule = true;
+	exports['default'] = shouldPureComponentUpdate;
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+	var _shallowEqual = __webpack_require__(361);
+
+	var _shallowEqual2 = _interopRequireDefault(_shallowEqual);
+
+	function shouldPureComponentUpdate(nextProps, nextState) {
+	  return !(0, _shallowEqual2['default'])(this.props, nextProps) || !(0, _shallowEqual2['default'])(this.state, nextState);
+	}
+
+	module.exports = exports['default'];
+
+/***/ },
+/* 361 */
+/***/ function(module, exports) {
+
+	'use strict';
+
+	exports.__esModule = true;
+	exports['default'] = shallowEqual;
+
+	function shallowEqual(objA, objB) {
+	  if (objA === objB) {
+	    return true;
+	  }
+
+	  if (typeof objA !== 'object' || objA === null || typeof objB !== 'object' || objB === null) {
+	    return false;
+	  }
+
+	  var keysA = Object.keys(objA);
+	  var keysB = Object.keys(objB);
+
+	  if (keysA.length !== keysB.length) {
+	    return false;
+	  }
+
+	  // Test for A's keys different from B.
+	  var bHasOwnProperty = Object.prototype.hasOwnProperty.bind(objB);
+	  for (var i = 0; i < keysA.length; i++) {
+	    if (!bHasOwnProperty(keysA[i]) || objA[keysA[i]] !== objB[keysA[i]]) {
+	      return false;
+	    }
+	  }
+
+	  return true;
+	}
+
+	module.exports = exports['default'];
+
+/***/ },
+/* 362 */
+/***/ function(module, exports) {
+
+	// removed by extract-text-webpack-plugin
+
+/***/ },
+/* 363 */
+/***/ function(module, exports, __webpack_require__) {
+
+	"use strict";
+
+	/** @ssr-ready **/
+
+	/**
+	 * External Dependencies
+	 */
+	var React = __webpack_require__(4);
+
+	var SelectDropdownSeparator = React.createClass({
+		displayName: "SelectDropdownSeparator",
+
+
+		render: function render() {
+			return React.createElement("li", { className: "dops-select-dropdown__separator" });
+		}
+	});
+
+	module.exports = SelectDropdownSeparator;
+
+/***/ },
+/* 364 */
+/***/ function(module, exports, __webpack_require__) {
+
+	"use strict";
+
+	Object.defineProperty(exports, "__esModule", {
+		value: true
+	});
+
+	var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+	var _react = __webpack_require__(4);
+
+	var _react2 = _interopRequireDefault(_react);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+	function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+	function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; } /** @ssr-ready **/
+
+	/**
+	 * External Dependencies
+	 */
+
+
+	/**
+	 * Module variables
+	 */
+	var Component = _react2.default.Component;
+
+	var stopPropagation = function stopPropagation(event) {
+		return event.stopPropagation();
+	};
+
+	var SelectDropdownLabel = function (_Component) {
+		_inherits(SelectDropdownLabel, _Component);
+
+		function SelectDropdownLabel() {
+			_classCallCheck(this, SelectDropdownLabel);
+
+			return _possibleConstructorReturn(this, (SelectDropdownLabel.__proto__ || Object.getPrototypeOf(SelectDropdownLabel)).apply(this, arguments));
+		}
+
+		_createClass(SelectDropdownLabel, [{
+			key: "render",
+			value: function render() {
+				return _react2.default.createElement(
+					"li",
+					{
+						onClick: stopPropagation,
+						className: "dops-select-dropdown__label"
+					},
+					_react2.default.createElement(
+						"label",
+						null,
+						this.props.children
+					)
+				);
+			}
+		}]);
+
+		return SelectDropdownLabel;
+	}(Component);
+
+	exports.default = SelectDropdownLabel;
+	;
+	module.exports = exports["default"];
+
+/***/ },
+/* 365 */
+/***/ function(module, exports) {
+
+	// removed by extract-text-webpack-plugin
+
+/***/ },
+/* 366 */
+/***/ function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	var React = __webpack_require__(4),
 	    Button = __webpack_require__(224),
 	    SiteStore = __webpack_require__(215),
 	    Paths = __webpack_require__(175),
-	    Dashicon = __webpack_require__(271),
+	    Dashicon = __webpack_require__(367),
 	    SetupProgressActions = __webpack_require__(174),
 	    WelcomeSection = __webpack_require__(259);
 
@@ -5800,7 +9582,7 @@ webpackJsonp([1],[
 	module.exports = AdvancedSettingsStep;
 
 /***/ },
-/* 271 */
+/* 367 */
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';

--- a/dist/jetpack-onboarding.js
+++ b/dist/jetpack-onboarding.js
@@ -5586,6 +5586,9 @@ webpackJsonp([1],[
 		render: function render() {
 			var _this = this;
 
+			if (!this.state.is_store) {
+				this.goToJpoReview();
+			}
 			var platformSelections = platforms.map(function (platform, i) {
 				return React.createElement(
 					DropdownItem,

--- a/dist/jetpack-onboarding.js
+++ b/dist/jetpack-onboarding.js
@@ -5552,7 +5552,7 @@ webpackJsonp([1],[
 		};
 	}
 
-	var platforms = ['Shopify', 'BigCommerce', 'Magento', 'Woo', 'osCommerce', 'Wix', 'Other'];
+	var platforms = ['Shopify', 'BigCommerce', 'Magento', 'WooCommerce', 'osCommerce', 'Wix', 'Other'];
 
 	module.exports = React.createClass({
 		displayName: 'exports',
@@ -5586,9 +5586,10 @@ webpackJsonp([1],[
 		render: function render() {
 			var _this = this;
 
-			if (!this.state.is_store) {
+			if (!this.state.wooCommerceStatus) {
 				this.goToJpoReview();
 			}
+
 			var platformSelections = platforms.map(function (platform, i) {
 				return React.createElement(
 					DropdownItem,

--- a/dist/jetpack-onboarding.js
+++ b/dist/jetpack-onboarding.js
@@ -5628,12 +5628,12 @@ webpackJsonp([1],[
 					),
 					React.createElement(
 						Button,
-						{ primary: true },
+						{ primary: true, onClick: this.goToJpoReview },
 						'Next'
 					),
 					React.createElement(
 						Button,
-						null,
+						{ onClick: this.goToJpoReview },
 						'Nope'
 					)
 				)


### PR DESCRIPTION
Adds a new step after returning from setting up WooCommerce. The positioning of this step is a little awkward - you'll see it if you "Install WooCommerce" then opt out of the WC wizard, or if we detect you already have WC installed.

![screen shot 2016-11-10 at 3 24 47 pm](https://cloud.githubusercontent.com/assets/541093/20194624/174213c0-a761-11e6-873f-0ae9d9d3c742.png)

To test:

- Check out this branch
- Go through the business flow
- Install WooCommerce, then opt-out of the WC wizard
- OR go through the WC wizard, and click "back to dashboard" at the end (small grey text under the box)
- You should return to this step, where you can select a store - selecting one automatically sends the store to the completed step event tracking, and takes you to the review.
- Clicking No goes directly to the review.
- Clicking Next also just takes you to the review, without sending an event, since you haven't selected anything.

@jessefriedman @johnHackworth @roccotripaldi @tyxla 